### PR TITLE
feat: add release instructions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: "🚀 Release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "New version (semver)"
+        required: true
+        type: string
+      tag:
+        description: "Optional npm dist-tag"
+        required: false
+        type: string
+        default: latest
+
+jobs:
+  release:
+    uses: Unleash/.github/.github/workflows/npm-release.yml@v2.0.0
+    with:
+      version: ${{ github.event.inputs.version }}
+      tag: ${{ github.event.inputs.tag }}
+    secrets:
+      NPM_ACCESS_TOKEN: ${{ secrets.NPM_TOKEN }}
+      UNLEASH_BOT_APP_ID: ${{ secrets.UNLEASH_BOT_APP_ID }}
+      UNLEASH_BOT_PRIVATE_KEY: ${{ secrets.UNLEASH_BOT_PRIVATE_KEY }}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ This initial release focuses on the `feature_flag.create` tool. Future phases wi
 - An Unleash instance (hosted or self-hosted)
 - A Personal Access Token (PAT) from Unleash
 
+### Quick start (npx)
+
+You can run the MCP server without cloning the repository by installing it on the fly with `npx`. Provide your configuration as environment variables or via a local `.env` file in the directory where you run the command:
+
+```bash
+UNLEASH_BASE_URL=https://app.unleash-hosted.com/your-instance \
+UNLEASH_PAT=your-personal-access-token \
+UNLEASH_DEFAULT_PROJECT=default \
+npx unleash-mcp --log-level debug
+```
+
+The CLI supports the same flags as the local build (`--dry-run`, `--log-level`).
+
 ### Setup
 
 1. **Clone and install dependencies:**

--- a/package.json
+++ b/package.json
@@ -4,11 +4,16 @@
   "description": "MCP server for managing Unleash feature flags",
   "type": "module",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "unleash-mcp": "dist/index.js"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsx src/index.ts",
     "lint": "tsc --noEmit",
-    "test": "vitest"
+    "test": "vitest",
+    "prepack": "npm run build"
   },
   "keywords": [
     "mcp",
@@ -27,6 +32,12 @@
     "tsx": "^4.19.2",
     "typescript": "^5.7.2",
     "vitest": "^2.1.8"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Summary

- expose dist/index.js as the package entry with CLI bin + type declarations so it can run via npx
- document zero-install usage in README and tighten the published fileset for npm
- add the reusable Unleash npm release workflow for manual versioned publishes