### PR TITLE
feat: add two resources: projects and features per project

### DIFF
--- a/src/resources/unleashResources.ts
+++ b/src/resources/unleashResources.ts
@@ -1,0 +1,116 @@
+import type {
+  Resource,
+  ResourceTemplate,
+  TextResourceContents,
+} from '@modelcontextprotocol/sdk/types.js';
+
+import type { ServerContext } from '../context.js';
+
+export const PROJECTS_RESOURCE_URI = 'unleash://projects';
+export const FEATURE_FLAGS_RESOURCE_TEMPLATE =
+  'unleash://projects/{projectId}/feature-flags';
+
+export function listStaticResources(): Resource[] {
+  const resources: Resource[] = [
+    {
+      name: 'unleash-projects',
+      uri: PROJECTS_RESOURCE_URI,
+      mimeType: 'application/json',
+      description:
+        'Current Unleash projects with their names and descriptions. Use to choose an appropriate project instead of the default.',
+    },
+  ];
+
+  return resources;
+}
+
+export function listResourceTemplates(): ResourceTemplate[] {
+  return [
+    {
+      name: 'unleash-feature-flags-by-project',
+      uriTemplate: FEATURE_FLAGS_RESOURCE_TEMPLATE,
+      mimeType: 'application/json',
+      description:
+        'Feature flags for a specific Unleash project. Replace {projectId} to inspect existing flags before creating new ones.',
+    },
+  ];
+}
+
+export async function readProjectsResource(
+  context: ServerContext
+): Promise<TextResourceContents> {
+  try {
+    const projects = await context.unleashClient.listProjects();
+
+    const sorted = [...projects].sort((a, b) => a.name.localeCompare(b.name));
+
+    return {
+      uri: PROJECTS_RESOURCE_URI,
+      mimeType: 'application/json',
+      text: JSON.stringify(
+        {
+          fetchedAt: new Date().toISOString(),
+          dryRun: context.config.server.dryRun,
+          projects: sorted,
+        },
+        null,
+        2
+      ),
+    };
+  } catch (error) {
+    context.logger.error('Failed to read Unleash projects resource', error);
+    throw error;
+  }
+}
+
+export async function readFeatureFlagsResource(
+  context: ServerContext,
+  projectId: string
+): Promise<TextResourceContents> {
+  try {
+    const flags = await context.unleashClient.listFeatureFlags(projectId);
+
+    const sorted = [...flags].sort((a, b) => {
+      return a.name.localeCompare(b.name);
+    });
+
+    return {
+      uri: buildFeatureFlagsUri(projectId),
+      mimeType: 'application/json',
+      text: JSON.stringify(
+        {
+          fetchedAt: new Date().toISOString(),
+          dryRun: context.config.server.dryRun,
+          projectId,
+          flags: sorted,
+        },
+        null,
+        2
+      ),
+    };
+  } catch (error) {
+    context.logger.error('Failed to read Unleash feature flags resource', error);
+    throw error;
+  }
+}
+
+export function isFeatureFlagsUri(uri: string): boolean {
+  return /^unleash:\/\/projects\/[^/]+\/feature-flags$/.test(uri);
+}
+
+export function extractProjectIdFromFeatureUri(uri: string): string | undefined {
+  const match = uri.match(/^unleash:\/\/projects\/([^/]+)\/feature-flags$/);
+  if (!match) {
+    return undefined;
+  }
+
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
+}
+
+export function buildFeatureFlagsUri(projectId: string): string {
+  return `unleash://projects/${encodeURIComponent(projectId)}/feature-flags`;
+}

--- a/src/resources/unleashResources.ts
+++ b/src/resources/unleashResources.ts
@@ -5,53 +5,65 @@ import type {
 } from '@modelcontextprotocol/sdk/types.js';
 
 import type { ServerContext } from '../context.js';
+import type { FeatureFlagSummary, UnleashProjectSummary } from '../unleash/client.js';
 
 export const PROJECTS_RESOURCE_URI = 'unleash://projects';
+export const PROJECTS_RESOURCE_TEMPLATE = 'unleash://projects{?limit,order,offset}';
 export const FEATURE_FLAGS_RESOURCE_TEMPLATE =
-  'unleash://projects/{projectId}/feature-flags';
+  'unleash://projects/{projectId}/feature-flags{?limit,order,offset}';
+
+const DEFAULT_PROJECT_PAGE_SIZE = 20;
+const DEFAULT_FLAG_PAGE_SIZE = 50;
 
 export function listStaticResources(): Resource[] {
-  const resources: Resource[] = [
-    {
-      name: 'unleash-projects',
-      uri: PROJECTS_RESOURCE_URI,
-      mimeType: 'application/json',
-      description:
-        'Current Unleash projects with their names and descriptions. Use to choose an appropriate project instead of the default.',
-    },
-  ];
-
-  return resources;
+  return [];
 }
 
 export function listResourceTemplates(): ResourceTemplate[] {
   return [
     {
+      name: 'unleash-projects-filtered',
+      uriTemplate: PROJECTS_RESOURCE_TEMPLATE,
+      mimeType: 'application/json',
+      description:
+        'Unleash projects with optional query parameters. Use limit to control page size, order=asc|desc to sort by creation time, and offset to paginate.',
+    },
+    {
       name: 'unleash-feature-flags-by-project',
       uriTemplate: FEATURE_FLAGS_RESOURCE_TEMPLATE,
       mimeType: 'application/json',
       description:
-        'Feature flags for a specific Unleash project. Replace {projectId} to inspect existing flags before creating new ones.',
+        'Feature flags for a specific Unleash project. Replace {projectId}; optional limit/order/offset parameters help paginate flags alphabetically.',
     },
   ];
 }
 
 export async function readProjectsResource(
-  context: ServerContext
+  context: ServerContext,
+  options: { limit?: number; order?: 'asc' | 'desc'; offset?: number } = {}
 ): Promise<TextResourceContents> {
   try {
-    const projects = await context.unleashClient.listProjects();
+    const { projects, fetchedAt, fromCache } = await getCachedProjects(context);
 
-    const sorted = [...projects].sort((a, b) => a.name.localeCompare(b.name));
+    const order = options.order ?? 'desc';
+    const sorted = sortProjects(projects, order);
+    const effectiveLimit = options.limit ?? DEFAULT_PROJECT_PAGE_SIZE;
+    const { slice, nextOffset } = applyPagination(sorted, effectiveLimit, options.offset);
 
     return {
-      uri: PROJECTS_RESOURCE_URI,
+      uri: buildProjectsUri({ ...options, limit: effectiveLimit }),
       mimeType: 'application/json',
       text: JSON.stringify(
         {
-          fetchedAt: new Date().toISOString(),
+          fetchedAt: new Date(fetchedAt).toISOString(),
+          cached: fromCache,
           dryRun: context.config.server.dryRun,
-          projects: sorted,
+          order,
+          limit: effectiveLimit,
+          offset: options.offset ?? 0,
+          nextOffset,
+          totalProjects: projects.length,
+          projects: slice,
         },
         null,
         2
@@ -65,24 +77,32 @@ export async function readProjectsResource(
 
 export async function readFeatureFlagsResource(
   context: ServerContext,
-  projectId: string
+  projectId: string,
+  options: { limit?: number; order?: 'asc' | 'desc'; offset?: number } = {}
 ): Promise<TextResourceContents> {
   try {
-    const flags = await context.unleashClient.listFeatureFlags(projectId);
+    const { flags, fetchedAt, fromCache } = await getCachedFeatureFlags(context, projectId);
 
-    const sorted = [...flags].sort((a, b) => {
-      return a.name.localeCompare(b.name);
-    });
+    const order = options.order ?? 'asc';
+    const sorted = sortFeatureFlags(flags, order);
+    const effectiveLimit = options.limit ?? DEFAULT_FLAG_PAGE_SIZE;
+    const { slice, nextOffset } = applyPagination(sorted, effectiveLimit, options.offset);
 
     return {
-      uri: buildFeatureFlagsUri(projectId),
+      uri: buildFeatureFlagsUri(projectId, { ...options, limit: effectiveLimit }),
       mimeType: 'application/json',
       text: JSON.stringify(
         {
-          fetchedAt: new Date().toISOString(),
+          fetchedAt: new Date(fetchedAt).toISOString(),
+          cached: fromCache,
           dryRun: context.config.server.dryRun,
           projectId,
-          flags: sorted,
+          order,
+          limit: effectiveLimit,
+          offset: options.offset ?? 0,
+          nextOffset,
+          totalFlags: flags.length,
+          flags: slice,
         },
         null,
         2
@@ -95,11 +115,46 @@ export async function readFeatureFlagsResource(
 }
 
 export function isFeatureFlagsUri(uri: string): boolean {
-  return /^unleash:\/\/projects\/[^/]+\/feature-flags$/.test(uri);
+  return /^unleash:\/\/projects\/[^/]+\/feature-flags(?:\?.*)?$/.test(uri);
+}
+
+export function isProjectsUri(uri: string): boolean {
+  return uri === PROJECTS_RESOURCE_URI || uri.startsWith(`${PROJECTS_RESOURCE_URI}?`);
+}
+
+export function parseProjectsResourceOptions(
+  uri: string
+): { limit?: number; order?: 'asc' | 'desc'; offset?: number } {
+  if (!isProjectsUri(uri)) {
+    return {};
+  }
+
+  const queryIndex = uri.indexOf('?');
+  if (queryIndex === -1) {
+    return {};
+  }
+
+  const query = uri.slice(queryIndex + 1);
+  const params = new URLSearchParams(query);
+
+  const limitParam = params.get('limit');
+  const orderParam = params.get('order');
+  const offsetParam = params.get('offset');
+
+  const limit = limitParam ? parsePositiveInteger(limitParam) : undefined;
+  const order = normalizeOrder(orderParam);
+  const offset = offsetParam ? parseNonNegativeInteger(offsetParam) : undefined;
+
+  return {
+    limit,
+    order,
+    offset,
+  };
 }
 
 export function extractProjectIdFromFeatureUri(uri: string): string | undefined {
-  const match = uri.match(/^unleash:\/\/projects\/([^/]+)\/feature-flags$/);
+  const baseUri = uri.split('?')[0];
+  const match = baseUri.match(/^unleash:\/\/projects\/([^/]+)\/feature-flags$/);
   if (!match) {
     return undefined;
   }
@@ -111,6 +166,264 @@ export function extractProjectIdFromFeatureUri(uri: string): string | undefined 
   }
 }
 
-export function buildFeatureFlagsUri(projectId: string): string {
-  return `unleash://projects/${encodeURIComponent(projectId)}/feature-flags`;
+export function parseFeatureFlagsResourceOptions(
+  uri: string
+): { limit?: number; order?: 'asc' | 'desc'; offset?: number } {
+  if (!isFeatureFlagsUri(uri)) {
+    return {};
+  }
+
+  const queryIndex = uri.indexOf('?');
+  if (queryIndex === -1) {
+    return {};
+  }
+
+  const query = uri.slice(queryIndex + 1);
+  const params = new URLSearchParams(query);
+
+  const limitParam = params.get('limit');
+  const orderParam = params.get('order');
+  const offsetParam = params.get('offset');
+
+  const limit = limitParam ? parsePositiveInteger(limitParam) : undefined;
+  const order = orderParam ? normalizeOrder(orderParam) : undefined;
+  const offset = offsetParam ? parseNonNegativeInteger(offsetParam) : undefined;
+
+  return {
+    limit,
+    order,
+    offset,
+  };
+}
+
+export function buildFeatureFlagsUri(
+  projectId: string,
+  options: { limit?: number; order?: 'asc' | 'desc'; offset?: number } = {}
+): string {
+  const base = `unleash://projects/${encodeURIComponent(projectId)}/feature-flags`;
+  const params = new URLSearchParams();
+
+  if (typeof options.limit === 'number') {
+    params.set('limit', String(options.limit));
+  }
+
+  if (options.order) {
+    params.set('order', options.order);
+  }
+
+  if (typeof options.offset === 'number') {
+    params.set('offset', String(options.offset));
+  }
+
+  const query = params.toString();
+  return query ? `${base}?${query}` : base;
+}
+
+function buildProjectsUri(options: { limit?: number; order?: 'asc' | 'desc'; offset?: number }): string {
+  const params = new URLSearchParams();
+
+  if (typeof options.limit === 'number') {
+    params.set('limit', String(options.limit));
+  }
+
+  if (options.order) {
+    params.set('order', options.order);
+  }
+
+  if (typeof options.offset === 'number') {
+    params.set('offset', String(options.offset));
+  }
+
+  const query = params.toString();
+  return query ? `${PROJECTS_RESOURCE_URI}?${query}` : PROJECTS_RESOURCE_URI;
+}
+
+function sortProjects(
+  projects: UnleashProjectSummary[],
+  order: 'asc' | 'desc'
+): UnleashProjectSummary[] {
+  const direction = order === 'asc' ? 1 : -1;
+
+  return [...projects].sort((a, b) => {
+    const dateA = a.createdAt ? Date.parse(a.createdAt) : Number.NaN;
+    const dateB = b.createdAt ? Date.parse(b.createdAt) : Number.NaN;
+
+    const hasDateA = Number.isFinite(dateA);
+    const hasDateB = Number.isFinite(dateB);
+
+    if (hasDateA && !hasDateB) {
+      return -1;
+    }
+
+    if (!hasDateA && hasDateB) {
+      return 1;
+    }
+
+    if (hasDateA && hasDateB) {
+      if (dateA === dateB) {
+        return a.name.localeCompare(b.name) * direction;
+      }
+      return (dateA - dateB) * direction;
+    }
+
+    return a.name.localeCompare(b.name) * direction;
+  });
+}
+
+function sortFeatureFlags(
+  flags: FeatureFlagSummary[],
+  order: 'asc' | 'desc'
+): FeatureFlagSummary[] {
+  const direction = order === 'asc' ? 1 : -1;
+
+  return [...flags].sort((a, b) => {
+    const nameA = a.name ?? '';
+    const nameB = b.name ?? '';
+
+    if (nameA === nameB) {
+      const dateA = a.createdAt ? Date.parse(a.createdAt) : Number.NaN;
+      const dateB = b.createdAt ? Date.parse(b.createdAt) : Number.NaN;
+
+      if (Number.isFinite(dateA) && Number.isFinite(dateB)) {
+        return (dateA - dateB) * direction;
+      }
+
+      return 0;
+    }
+
+    return nameA.localeCompare(nameB) * direction;
+  });
+}
+
+function applyPagination<T>(
+  items: T[],
+  limit?: number,
+  offset?: number
+): { slice: T[]; nextOffset?: number } {
+  const safeLimit = typeof limit === 'number' && Number.isFinite(limit)
+    ? Math.max(0, Math.floor(limit))
+    : undefined;
+  const safeOffset = typeof offset === 'number' && Number.isFinite(offset)
+    ? Math.max(0, Math.floor(offset))
+    : 0;
+
+  const start = safeOffset;
+  const end = safeLimit !== undefined ? start + safeLimit : undefined;
+
+  const slice = items.slice(start, end);
+
+  const nextOffset = safeLimit !== undefined && start + safeLimit < items.length
+    ? start + safeLimit
+    : undefined;
+
+  return {
+    slice,
+    nextOffset,
+  };
+}
+
+function parsePositiveInteger(value: string): number | undefined {
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed;
+  }
+
+  return undefined;
+}
+
+function parseNonNegativeInteger(value: string): number | undefined {
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isFinite(parsed) && parsed >= 0) {
+    return parsed;
+  }
+
+  return undefined;
+}
+
+function normalizeOrder(value: string | null): 'asc' | 'desc' | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const lower = value.toLowerCase();
+  if (lower === 'asc' || lower === 'desc') {
+    return lower;
+  }
+
+  return undefined;
+}
+
+const PROJECTS_CACHE_TTL_MS = 60_000;
+let cachedProjects: {
+  data: UnleashProjectSummary[];
+  fetchedAt: number;
+} | null = null;
+
+const FEATURE_FLAGS_CACHE_TTL_MS = 60_000;
+const cachedFeatureFlags = new Map<
+  string,
+  {
+    data: FeatureFlagSummary[];
+    fetchedAt: number;
+  }
+>();
+
+async function getCachedProjects(context: ServerContext): Promise<{
+  projects: UnleashProjectSummary[];
+  fetchedAt: number;
+  fromCache: boolean;
+}> {
+  const now = Date.now();
+
+  if (cachedProjects && now - cachedProjects.fetchedAt < PROJECTS_CACHE_TTL_MS) {
+    return {
+      projects: cachedProjects.data,
+      fetchedAt: cachedProjects.fetchedAt,
+      fromCache: true,
+    };
+  }
+
+  const data = await context.unleashClient.listProjects();
+  cachedProjects = {
+    data,
+    fetchedAt: now,
+  };
+
+  return {
+    projects: data,
+    fetchedAt: now,
+    fromCache: false,
+  };
+}
+
+async function getCachedFeatureFlags(
+  context: ServerContext,
+  projectId: string
+): Promise<{
+  flags: FeatureFlagSummary[];
+  fetchedAt: number;
+  fromCache: boolean;
+}> {
+  const now = Date.now();
+  const cached = cachedFeatureFlags.get(projectId);
+
+  if (cached && now - cached.fetchedAt < FEATURE_FLAGS_CACHE_TTL_MS) {
+    return {
+      flags: cached.data,
+      fetchedAt: cached.fetchedAt,
+      fromCache: true,
+    };
+  }
+
+  const data = await context.unleashClient.listFeatureFlags(projectId);
+  cachedFeatureFlags.set(projectId, {
+    data,
+    fetchedAt: now,
+  });
+
+  return {
+    flags: data,
+    fetchedAt: now,
+    fromCache: false,
+  };
 }


### PR DESCRIPTION
## About the changes
Introduce 2 resources to help guide the LLM on the decision of what project to use and what feature flag to use.

### Core capabilities:
1. Get all projects with descriptions and creation time
2. Get features per project with descriptions and creation time

### Sample prompt
```
› Can you show me the newest projects in Unleash using their MCP server?



• Called codex.list_mcp_resource_templates({})
  └ {"resourceTemplates": [{"server": "unleash", "description": "Unleash projects with optional query parameters. Use limit to control page size, order=asc|desc to sort by creation time, and
        offset to paginate.", "mimeType": "application/json", "name": "unleash-projects-filtered", "uriTemplate": "unleash://projects{?limit,order,offset}"}, {"server": "unleash",
        "description": "Feature flags for a specific Unleash project. Replace {projectId}; optional limit/order/offset parameters help paginate flags alphabetically.", "mimeType":
        "application/json", "name": "unleash-feature-flags-by-project", "uriTemplate": "unleash://projects/{projectId}/feature-flags{?limit,order,offset}"}]}
  └ {"server": "unleash", "uri": "unleash://projects?limit=5&order=desc", "contents": [{"mimeType": "application/json", "text": "{\n  \"fetchedAt\": \"2025-11-04T16:16:23.626Z\",
        \n  \"cached\": false,\n  \"dryRun\": false,\n  \"order\": \"desc\",\n  \"limit\": 5,\n  \"offset\": 0,\n  \"nextOffset\": 5,\n  \"totalProjects\": 264,\n  \"projects\":
        [\n    {\n      \"id\": \"testing-break-project\",\n      \"name\": \"Testing-break-project\",\n      \"description\": \"\",\n      \"mode\": \"open\",\n      \"createdAt\":
        \"2025-10-30T14:12:03.047Z\",\n      \"url\": \"https://sandbox.getunleash.io/enterprise/projects/testing-break-project\"\n    },\n    {\n      \"id\": \"gaston-release-plan-
        automation-breakathon\",\n      \"name\": \"gaston-release-plan-automation-breakathon\",\n      \"description\": \"\",\n      \"mode\": \"open\",\n      \"createdAt\": \"2025-10-
        30T14:08:50.603Z\",\n      \"url\": \"https://sandbox.getunlea...

• Newest Unleash projects (newest first):

  - Testing-break-project (testing-break-project) — created 2025-10-30T14:12:03.047Z — https://sandbox.getunleash.io/enterprise/projects/testing-break-project
  - gaston-release-plan-automation-breakathon (gaston-release-plan-automation-breakathon) — created 2025-10-30T14:08:50.603Z — https://sandbox.getunleash.io/enterprise/projects/gaston-release-
    plan-automation-breakathon
  - Regression testing Cristian (regression-testing-cristian) — created 2025-10-17T14:34:24.381Z — https://sandbox.getunleash.io/enterprise/projects/regression-testing-cristian


› Can you check the default project and show me what are the newest flags and the oldest ones in that project?


• Called unleash.read_mcp_resource({"server":"unleash","uri":"unleash://projects/default/feature-flags?limit=5&order=desc"})
  └ {"server": "unleash", "uri": "unleash://projects/default/feature-flags?limit=5&order=desc", "contents": [{"mimeType": "application/json", "text": "{\n  \"fetchedAt\": \"2025-11-
        04T16:17:26.054Z\",\n  \"cached\": false,\n  \"dryRun\": false,\n  \"projectId\": \"default\",\n  \"order\": \"desc\",\n  \"limit\": 5,\n  \"offset\": 0,\n  \"nextOffset\": 5,
        \n  \"totalFlags\": 48,\n  \"flags\": [\n    {\n      \"name\": \"waaaat\",\n      \"description\": \"\",\n      \"project\": \"default\",\n      \"type\": \"release\",\n
        \"impressionData\": false,\n      \"createdAt\": \"2023-01-10T12:43:58.753Z\",\n      \"url\": \"https://sandbox.getunleash.io/enterprise/projects/default/features/waaaat\"\n    },
        \n    {\n      \"name\": \"very-long-feature-name-that-expands-the-container\",\n      \"description\": null,\n      \"project\": \"default\",\n      \"type\": \"release\",\n
        \"impressionData\": false,\n      \"createdA...

• Called unleash.read_mcp_resource({"server":"unleash","uri":"unleash://projects/default/feature-flags?limit=5&order=desc&sortBy=createdAt"})
  └ {"server": "unleash", "uri": "unleash://projects/default/feature-flags?limit=5&order=desc&sortBy=createdAt", "contents": [{"mimeType": "application/json", "text": "{\n  \"fetchedAt\":
        \"2025-11-04T16:17:26.054Z\",\n  \"cached\": true,\n  \"dryRun\": false,\n  \"projectId\": \"default\",\n  \"order\": \"desc\",\n  \"limit\": 5,\n  \"offset\": 0,\n  \"nextOffset\":
        5,\n  \"totalFlags\": 48,\n  \"flags\": [\n    {\n      \"name\": \"waaaat\",\n      \"description\": \"\",\n      \"project\": \"default\",\n      \"type\": \"release\",\n
        \"impressionData\": false,\n      \"createdAt\": \"2023-01-10T12:43:58.753Z\",\n      \"url\": \"https://sandbox.getunleash.io/enterprise/projects/default/features/waaaat\"\n    },
        \n    {\n      \"name\": \"very-long-feature-name-that-expands-the-container\",\n      \"description\": null,\n      \"project\": \"default\",\n      \"type\": \"release\",\n
        \"impressionData\": false,\n...

• Called unleash.read_mcp_resource({"server":"unleash","uri":"unleash://projects/default/feature-flags?limit=100"})
  └ {"server": "unleash", "uri": "unleash://projects/default/feature-flags?limit=100", "contents": [{"mimeType": "application/json", "text": "{\n  \"fetchedAt\": \"2025-11-04T16:17:26.054Z\",
  └ {"server": "unleash", "uri": "unleash://projects/default/feature-flags?limit=25&offset=0", "contents": [{"mimeType": "application/json", "text": "{\n  \"fetchedAt\": \"2025-11-
        04T16:17:26.054Z\",\n  \"cached\": true,\n  \"dryRun\": false,\n  \"projectId\": \"default\",\n  \"order\": \"asc\",\n  \"limit\": 25,\n  \"offset\": 0,\n  \"nextOffset\": 25,
        \n  \"totalFlags\": 48,\n  \"flags\": [\n    {\n      \"name\": \"16thflag\",\n      \"description\": null,\n      \"project\": \"default\",\n      \"type\": \"release\",\n
        \"impressionData\": false,\n      \"createdAt\": \"2024-07-17T13:21:41.509Z\",\n      \"url\": \"https://sandbox.getunleash.io/enterprise/projects/default/features/16thflag\"\n    },\n
        {\n      \"name\": \"8945760984\",\n      \"description\": null,\n      \"project\": \"default\",\n      \"type\": \"release\",\n      \"impressionData\": false,\n      \"createdAt\":
        \"2024-10-02T14:05:16.933Z\",\n...

• Called unleash.read_mcp_resource({"server":"unleash","uri":"unleash://projects/default/feature-flags?limit=25&offset=25"})
─ Worked for 36s ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

• Newest Flags

  - streaming-enforce-edge-sdk (streaming-enforce-edge-sdk) — created 2025-11-03T09:41:06.706Z — https://sandbox.getunleash.io/enterprise/projects/default/features/streaming-enforce-edge-sdk
  - mcp-created-2 (mcp-created-2) — created 2025-10-30T11:26:23.233Z — https://sandbox.getunleash.io/enterprise/projects/default/features/mcp-created-2
  - ai-generated-test-mcp (ai-generated-test-mcp) — created 2025-10-27T08:06:47.842Z — https://sandbox.getunleash.io/enterprise/projects/default/features/ai-generated-test-mcp
  - ai-generated-cr-progression-ui-cr-overview (ai-generated-cr-progression-ui-cr-overview) — created 2025-10-21T06:50:16.421Z — https://sandbox.getunleash.io/enterprise/projects/default/
    features/ai-generated-cr-progression-ui-cr-overview
  - ai-generated-cr-dialogue-update-progression (ai-generated-cr-dialogue-update-progression) — created 2025-10-20T09:32:39.546Z — https://sandbox.getunleash.io/enterprise/projects/default/
    features/ai-generated-cr-dialogue-update-progression

  Oldest Flags

  - Test2 (Test2) — created 2022-09-07T10:32:20.019Z — https://sandbox.getunleash.io/enterprise/projects/default/features/Test2
  - test-toggle (test-toggle) — created 2022-09-28T09:07:59.678Z — https://sandbox.getunleash.io/enterprise/projects/default/features/test-toggle
  - waaaat (waaaat) — created 2023-01-10T12:43:58.753Z — https://sandbox.getunleash.io/enterprise/projects/default/features/waaaat
  - test_strat (test_strat) — created 2023-01-11T08:22:05.134Z — https://sandbox.getunleash.io/enterprise/projects/default/features/test_strat
  - enabledOnArchive (enabledOnArchive) — created 2023-10-13T14:06:55.850Z — https://sandbox.getunleash.io/enterprise/projects/default/features/enabledOnArchive

/mcp

🔌  MCP Tools

  • unleash
    • Status: enabled
    • Auth: Unsupported
    • Command: node /home/gaston/projects/unleash-mcp/dist/index.js --log-level error
    • Env: UNLEASH_BASE_URL=*****, UNLEASH_DEFAULT_PROJECT=*****, UNLEASH_PAT=*****
    • Tools: create_flag, detect_flag, evaluate_change, wrap_change
    • Resources: (none)
    • Resource templates: unleash-projects-filtered (unleash://projects{?limit,order,offset}), unleash-feature-flags-by-project (unleash://projects/{projectId}/feature-flags{?
limit,order,offset})
```
