### PR TITLE
feat: add cleanup_flag tool for removing feature flags

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import { createFlag, createFlagTool } from './tools/createFlag.js';
 import { evaluateChange, evaluateChangeTool } from './tools/evaluateChange.js';
 import { wrapChange, wrapChangeTool } from './tools/wrapChange.js';
 import { detectFlag, detectFlagTool } from './tools/detectFlag.js';
+import { cleanupFlag, cleanupFlagTool } from './tools/cleanupFlag.js';
 import { VERSION } from './version.js';
 
 /**
@@ -68,6 +69,7 @@ async function main(): Promise<void> {
     '2) The evaluate_change tool will automatically call detect_flag to search for existing flags to prevent duplicates.',
     '3) If an existing flag is found, use it. If the code change is risky and no flag exists, create a feature flag with create_flag.',
     '4) Use wrap_change to guard code with an Unleash flag.',
+    '5) When a flag is rolled out and ready to be removed, use cleanup_flag to safely remove the flag code while preserving the desired path.',
   ].join('\n');
 
   // Create MCP server
@@ -101,7 +103,7 @@ async function main(): Promise<void> {
   // Register tool handlers
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     return {
-      tools: [createFlagTool, evaluateChangeTool, detectFlagTool, wrapChangeTool],
+      tools: [createFlagTool, evaluateChangeTool, detectFlagTool, wrapChangeTool, cleanupFlagTool],
     };
   });
 
@@ -123,6 +125,9 @@ async function main(): Promise<void> {
 
         case 'wrap_change':
           return await wrapChange(context, args);
+
+        case 'cleanup_flag':
+          return await cleanupFlag(context, args);
 
         default:
           throw new Error(`Unknown tool: ${name}`);

--- a/src/templates/cleanupGuidance.ts
+++ b/src/templates/cleanupGuidance.ts
@@ -1,0 +1,435 @@
+/**
+ * Cleanup Guidance Generator
+ *
+ * Generates comprehensive instructions for LLMs to safely remove feature flag
+ * code while preserving the desired code path (enabled or disabled).
+ */
+
+import { SupportedLanguage, getLanguageMetadata } from './languages.js';
+
+/**
+ * Preserve path option - which code path to keep
+ */
+export type PreservePath = 'enabled' | 'disabled';
+
+/**
+ * Generate comprehensive cleanup instructions
+ */
+export function generateCleanupInstructions(
+  flagName: string,
+  preservePath: PreservePath,
+  files?: string[]
+): string {
+  const searchScope = files && files.length > 0
+    ? `specific files: ${files.join(', ')}`
+    : 'the entire codebase';
+
+  return `# Feature Flag Cleanup Instructions: "${flagName}"
+
+## ⚠️ IMPORTANT: Safety First
+
+Before you begin:
+1. **Backup**: Ensure the current code is committed or backed up
+2. **Tests**: Make sure tests exist and pass before cleanup
+3. **Understanding**: You will preserve the **${preservePath.toUpperCase()} path** (remove the ${preservePath === 'enabled' ? 'disabled' : 'enabled'} path)
+
+---
+
+## Overview
+
+You are removing the feature flag "${flagName}" from ${searchScope}.
+
+**Goal**: Remove all flag checks while preserving only the **${preservePath}** code path.
+
+**What this means**:
+${preservePath === 'enabled'
+  ? '- Keep code that runs when the flag is ENABLED/TRUE\n- Remove code that runs when the flag is DISABLED/FALSE'
+  : '- Keep code that runs when the flag is DISABLED/FALSE\n- Remove code that runs when the flag is ENABLED/TRUE'
+}
+
+---
+
+${generateSearchInstructions(flagName, files)}
+
+---
+
+${generatePatternIdentificationInstructions(preservePath)}
+
+---
+
+${generateCleanupStrategies(preservePath)}
+
+---
+
+${generatePostCleanupChecklist()}
+
+---
+
+## Common Pitfalls to Avoid
+
+1. **Don't leave dead code**: Remove the flag check AND the unwanted path completely
+2. **Don't break indentation**: Maintain proper indentation after removing blocks
+3. **Don't forget imports**: Remove unused flag-related imports
+4. **Don't miss context providers**: Remove flag initialization code if no longer needed
+5. **Don't skip tests**: Update or remove tests that specifically test the removed path
+
+---
+
+## Expected Outcome
+
+After cleanup, the code should:
+- ✅ Run as if the flag is always **${preservePath}**
+- ✅ Have no references to "${flagName}"
+- ✅ Be clean, readable, and properly indented
+- ✅ Pass all existing tests (with test updates as needed)
+- ✅ Have no unused imports or dead code
+
+---
+
+## Reporting Results
+
+After completing the cleanup, provide:
+1. **Summary**: Number of files modified and total occurrences removed
+2. **Changes by file**: List each file with a brief description of what was removed
+3. **Potential issues**: Flag any complex cases that need manual review
+4. **Test status**: Whether tests pass after cleanup
+`;
+}
+
+/**
+ * Generate search instructions for finding flag occurrences
+ */
+function generateSearchInstructions(flagName: string, files?: string[]): string {
+  const fileScope = files && files.length > 0
+    ? `\n**Files to search**: ${files.map(f => `\`${f}\``).join(', ')}`
+    : '';
+
+  return `## Step 1: Find All Flag Occurrences
+${fileScope}
+
+Use the **Grep** tool to find all references to the flag:
+
+\`\`\`bash
+Grep pattern: "${flagName}" output_mode: "content" -n: true -C: 3
+\`\`\`
+
+This will show:
+- All lines containing the flag name
+- 3 lines of context before and after (to understand the pattern)
+- Line numbers for precise editing
+
+**What to look for**:
+- Direct flag checks: \`isEnabled('${flagName}')\`, \`is_enabled("${flagName}")\`
+- Variable assignments: \`const enabled = isEnabled('${flagName}')\`
+- Comments mentioning the flag
+- Test cases for the flag
+- Configuration or initialization code
+
+**Action**: Create a list of all files and line numbers where "${flagName}" appears.
+`;
+}
+
+/**
+ * Generate pattern identification instructions
+ */
+function generatePatternIdentificationInstructions(preservePath: PreservePath): string {
+  return `## Step 2: Identify Usage Patterns
+
+For each occurrence, identify what pattern is being used:
+
+### Pattern A: If-Else Block
+\`\`\`
+if (isEnabled('flag')) {
+  // Code A
+} else {
+  // Code B
+}
+\`\`\`
+**Action**: Remove the if-else, keep ${preservePath === 'enabled' ? 'Code A' : 'Code B'}.
+
+---
+
+### Pattern B: Guard Clause
+\`\`\`
+if (!isEnabled('flag')) {
+  return earlyExit;
+}
+// Main code here
+\`\`\`
+**Action**: ${preservePath === 'enabled'
+  ? 'Remove the guard clause (keep main code)'
+  : 'Keep the early exit, remove everything after'}.
+
+---
+
+### Pattern C: Ternary Operator
+\`\`\`
+const value = isEnabled('flag') ? valueA : valueB;
+\`\`\`
+**Action**: Replace with ${preservePath === 'enabled' ? '`const value = valueA;`' : '`const value = valueB;`'}
+
+---
+
+### Pattern D: Logical AND/OR
+\`\`\`
+isEnabled('flag') && doSomething();
+isEnabled('flag') || doFallback();
+\`\`\`
+**Action**: ${preservePath === 'enabled'
+  ? 'Replace `&&` with just the function call, remove `||` entirely'
+  : 'Remove `&&` statement entirely, replace `||` with just the function call'}.
+
+---
+
+### Pattern E: Component Rendering (React/JSX)
+\`\`\`
+{isEnabled('flag') && <Component />}
+{isEnabled('flag') ? <ComponentA /> : <ComponentB />}
+\`\`\`
+**Action**: ${preservePath === 'enabled'
+  ? 'Keep ComponentA/Component, remove the condition'
+  : 'Keep ComponentB or remove the entire block'}.
+
+---
+
+### Pattern F: Variable Assignment
+\`\`\`
+const isFlagEnabled = isEnabled('flag');
+if (isFlagEnabled) { ... }
+\`\`\`
+**Action**: Remove the variable assignment, then handle the if statement as Pattern A.
+
+---
+
+### Pattern G: Nested Conditions
+\`\`\`
+if (someCondition) {
+  if (isEnabled('flag')) {
+    // Nested code
+  }
+}
+\`\`\`
+**Action**: ${preservePath === 'enabled'
+  ? 'Remove inner flag check, keep nested code within outer condition'
+  : 'Remove the entire inner block'}.
+
+---
+
+**Important**: Use the **Read** tool to get full file context for complex patterns.
+`;
+}
+
+/**
+ * Generate cleanup strategies
+ */
+function generateCleanupStrategies(preservePath: PreservePath): string {
+  return `## Step 3: Execute Cleanup
+
+For each file containing the flag:
+
+### 3.1 Read the Full File
+\`\`\`bash
+Read file_path: "/path/to/file"
+\`\`\`
+
+### 3.2 Plan Your Edits
+- Identify all flag occurrences in the file
+- Note which pattern each one uses
+- Determine what code to keep vs remove
+- Check for any imports that will become unused
+
+### 3.3 Perform the Edits
+Use the **Edit** tool to make changes. Work from bottom to top of the file to preserve line numbers.
+
+**Example cleanup (preserving ${preservePath} path)**:
+
+${generateLanguageSpecificCleanupExamples(preservePath)}
+
+### 3.4 Clean Up Imports
+After removing flag checks, look for unused imports:
+
+**Common imports to remove if no longer used**:
+- TypeScript/JavaScript: \`import { useFlag } from '...'\`
+- Python: \`from unleash.client import UnleashClient\`
+- Go: \`import "github.com/Unleash/unleash-client-go/v3"\`
+- Ruby: \`require 'unleash'\`
+- Java: \`import io.getunleash.Unleash;\`
+
+**Action**: Use **Edit** tool to remove unused imports from each file.
+
+### 3.5 Clean Up Initialization Code (if applicable)
+If no flags remain in the file/project, consider removing:
+- Unleash client initialization
+- Flag context providers
+- Flag-related configuration
+
+**Only do this if you're certain no other flags exist in the codebase!**
+`;
+}
+
+/**
+ * Generate language-specific cleanup examples
+ */
+function generateLanguageSpecificCleanupExamples(preservePath: PreservePath): string {
+  if (preservePath === 'enabled') {
+    return `**Before (TypeScript)**:
+\`\`\`typescript
+if (unleash.isEnabled('new-feature')) {
+  return newImplementation();
+} else {
+  return oldImplementation();
+}
+\`\`\`
+
+**After**:
+\`\`\`typescript
+return newImplementation();
+\`\`\`
+
+---
+
+**Before (Python)**:
+\`\`\`python
+if unleash_client.is_enabled("new_feature"):
+    return new_implementation()
+else:
+    return old_implementation()
+\`\`\`
+
+**After**:
+\`\`\`python
+return new_implementation()
+\`\`\`
+
+---
+
+**Before (React/JSX)**:
+\`\`\`typescript
+{isEnabled('new-ui') ? <NewUI /> : <OldUI />}
+\`\`\`
+
+**After**:
+\`\`\`typescript
+<NewUI />
+\`\`\``;
+  } else {
+    return `**Before (TypeScript)**:
+\`\`\`typescript
+if (unleash.isEnabled('experimental-feature')) {
+  return experimentalImplementation();
+} else {
+  return stableImplementation();
+}
+\`\`\`
+
+**After**:
+\`\`\`typescript
+return stableImplementation();
+\`\`\`
+
+---
+
+**Before (Python)**:
+\`\`\`python
+if unleash_client.is_enabled("experimental_feature"):
+    return experimental_implementation()
+else:
+    return stable_implementation()
+\`\`\`
+
+**After**:
+\`\`\`python
+return stable_implementation()
+\`\`\`
+
+---
+
+**Before (React/JSX)**:
+\`\`\`typescript
+{isEnabled('beta-feature') && <BetaFeature />}
+\`\`\`
+
+**After**:
+\`\`\`typescript
+{/* BetaFeature removed - flag disabled */}
+\`\`\``;
+  }
+}
+
+/**
+ * Generate post-cleanup checklist
+ */
+function generatePostCleanupChecklist(): string {
+  return `## Step 4: Verify and Test
+
+After cleanup, perform these checks:
+
+### 4.1 Verify No References Remain
+Run another search to ensure the flag is completely removed:
+\`\`\`bash
+Grep pattern: "flag-name" output_mode: "files_with_matches"
+\`\`\`
+
+**Expected result**: No files should be returned (or only documentation/changelog).
+
+### 4.2 Check Syntax
+Ensure the code compiles/parses:
+- TypeScript/JavaScript: Run build or type check
+- Python: Check for syntax errors
+- Other languages: Run language-specific linter/compiler
+
+### 4.3 Run Tests
+\`\`\`bash
+# Run your test suite
+npm test
+# or pytest, go test, etc.
+\`\`\`
+
+**If tests fail**:
+- Update tests that specifically tested the removed code path
+- Remove tests that only make sense with the flag
+- Fix any logic errors introduced during cleanup
+
+### 4.4 Review Complex Cases
+For any complex patterns (deeply nested, multiple conditions), do a manual review:
+- Read the cleaned code
+- Ensure logic is correct
+- Check that error handling is preserved
+- Verify edge cases are still handled
+`;
+}
+
+/**
+ * Generate language-specific import removal guidance
+ */
+export function generateImportCleanupGuidance(language: SupportedLanguage): string {
+  const metadata = getLanguageMetadata(language);
+
+  const examples: Record<SupportedLanguage, string> = {
+    typescript: `- \`import { useFlag } from '@unleash/proxy-client-react'\`
+- \`import { UnleashClient } from 'unleash-client'\`
+- \`import unleash from './unleash'\``,
+    javascript: `- \`const { UnleashClient } = require('unleash-client');\`
+- \`import unleash from './unleash';\``,
+    python: `- \`from unleash.client import UnleashClient\`
+- \`import unleash\``,
+    go: `- \`import "github.com/Unleash/unleash-client-go/v3"\`
+- \`import unleash "github.com/Unleash/unleash-client-go/v3"\``,
+    ruby: `- \`require 'unleash'\`
+- \`require 'unleash/client'\``,
+    php: `- \`use Unleash\\Client\\UnleashBuilder;\`
+- \`use Unleash\\Client\\Configuration\\UnleashConfiguration;\``,
+    csharp: `- \`using Unleash;\`
+- \`using Unleash.ClientFactory;\``,
+    java: `- \`import io.getunleash.Unleash;\`
+- \`import io.getunleash.DefaultUnleash;\``,
+    rust: `- \`use unleash_api_client::client;\`
+- \`use unleash_api_client::Client;\``,
+  };
+
+  return `### Common ${metadata.displayName} imports to remove:
+${examples[language]}
+
+**Important**: Only remove these imports if they're no longer used anywhere in the file.
+`;
+}

--- a/src/tools/cleanupFlag.ts
+++ b/src/tools/cleanupFlag.ts
@@ -1,0 +1,335 @@
+/**
+ * Cleanup Flag Tool
+ *
+ * Provides comprehensive instructions for removing feature flag code from the codebase
+ * while preserving the desired code path (enabled or disabled).
+ *
+ * This tool follows the instruction-based pattern used by wrap_change and detect_flag:
+ * it returns detailed guidance for the LLM to execute the cleanup autonomously.
+ *
+ * Workflow:
+ * 1. User calls cleanup_flag with flag name and preserve path
+ * 2. Tool returns comprehensive cleanup instructions
+ * 3. LLM follows instructions to find and remove flag code
+ * 4. LLM reports back with summary of changes
+ */
+
+import { z } from 'zod';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { ServerContext, handleToolError } from '../context.js';
+import {
+  generateCleanupInstructions,
+  generateImportCleanupGuidance,
+  PreservePath,
+} from '../templates/cleanupGuidance.js';
+import { detectLanguage, SupportedLanguage } from '../templates/languages.js';
+
+/**
+ * Input schema for the cleanup_flag tool
+ */
+const cleanupFlagInputSchema = z.object({
+  flagName: z
+    .string()
+    .min(1)
+    .describe('Name of the feature flag to remove from the codebase'),
+  preservePath: z
+    .enum(['enabled', 'disabled'])
+    .optional()
+    .describe(
+      'Which code path to preserve: "enabled" keeps the code that runs when flag is true, "disabled" keeps the code that runs when flag is false. If not provided, instructions will guide you to ask the user.'
+    ),
+  files: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Optional: Specific files to clean up. If not provided, searches entire codebase'
+    ),
+  language: z
+    .string()
+    .optional()
+    .describe(
+      'Optional: Programming language hint for language-specific guidance (auto-detected from files if not provided)'
+    ),
+});
+
+type CleanupFlagInput = z.infer<typeof cleanupFlagInputSchema>;
+
+/**
+ * cleanup_flag tool implementation
+ *
+ * Returns comprehensive instructions for removing feature flag code while
+ * preserving the desired code path. The LLM follows these instructions to
+ * autonomously clean up the flag.
+ */
+export async function cleanupFlag(
+  context: ServerContext,
+  args: unknown
+): Promise<CallToolResult> {
+  try {
+    // Validate input
+    const input: CleanupFlagInput = cleanupFlagInputSchema.parse(args);
+
+    context.logger.info('Generating flag cleanup instructions', {
+      flagName: input.flagName,
+      preservePath: input.preservePath ?? 'not specified',
+      filesCount: input.files?.length ?? 0,
+      language: input.language,
+    });
+
+    // If preservePath not provided, return instructions to ask the user
+    if (!input.preservePath) {
+      return buildAskUserGuidance(input.flagName, input.files);
+    }
+
+    // Detect language if files provided and language not specified
+    let detectedLanguage: SupportedLanguage | undefined;
+    if (input.files && input.files.length > 0 && !input.language) {
+      // Try to detect from first file
+      detectedLanguage = detectLanguage(input.files[0], undefined) as SupportedLanguage;
+      context.logger.debug(`Detected language: ${detectedLanguage}`);
+    } else if (input.language) {
+      detectedLanguage = detectLanguage(undefined, input.language) as SupportedLanguage;
+    }
+
+    // Generate comprehensive cleanup instructions
+    const cleanupInstructions = generateCleanupInstructions(
+      input.flagName,
+      input.preservePath as PreservePath,
+      input.files
+    );
+
+    // Add language-specific import cleanup guidance if language detected
+    let importGuidance = '';
+    if (detectedLanguage) {
+      importGuidance = `\n---\n\n${generateImportCleanupGuidance(detectedLanguage)}`;
+    }
+
+    // Build complete guidance document
+    const guidance = buildCleanupGuidance(
+      input.flagName,
+      input.preservePath as PreservePath,
+      cleanupInstructions,
+      importGuidance,
+      input.files
+    );
+
+    context.logger.info(
+      `Generated cleanup guidance for flag "${input.flagName}" (preserve: ${input.preservePath})`
+    );
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: guidance,
+        },
+      ],
+      structuredContent: {
+        success: true,
+        flagName: input.flagName,
+        preservePath: input.preservePath,
+        targetFiles: input.files,
+        detectedLanguage,
+      },
+    };
+  } catch (error) {
+    return handleToolError(context, error, 'cleanup_flag');
+  }
+}
+
+/**
+ * Build guidance that instructs the LLM to ask the user which path to preserve
+ */
+function buildAskUserGuidance(flagName: string, files?: string[]): CallToolResult {
+  const scope = files && files.length > 0
+    ? `in ${files.length} specific file(s)`
+    : 'across the codebase';
+
+  const guidance = `# Feature Flag Cleanup: "${flagName}"
+
+## ⚠️ User Input Required
+
+Before proceeding with cleanup ${scope}, you need to determine which code path to preserve.
+
+---
+
+## Ask the User
+
+Use the **AskUserQuestion** tool to ask the user which path they want to keep:
+
+**Question**: "Which code path should be preserved when removing the '${flagName}' flag?"
+
+**Options**:
+1. **"enabled"** - Keep the code that runs when the flag is TRUE/enabled
+   - Use this when the feature has been rolled out successfully and you want to keep the new behavior
+   - This is the most common choice for completed feature rollouts
+
+2. **"disabled"** - Keep the code that runs when the flag is FALSE/disabled
+   - Use this when removing an experimental feature that didn't work out
+   - Use this for kill switches that are being removed
+   - Use this when reverting to the original behavior
+
+---
+
+## After the User Responds
+
+Once you know which path to preserve, call this tool again with the **preservePath** parameter:
+
+\`\`\`
+cleanup_flag({
+  flagName: "${flagName}",
+  preservePath: "enabled" or "disabled",  // Based on user's answer
+  ${files ? `files: ${JSON.stringify(files)}` : '// files: optional'}
+})
+\`\`\`
+
+---
+
+## Context to Help the User Decide
+
+Before asking, you may want to:
+1. Search for the flag to see how it's being used
+2. Check recent commits to understand the flag's history
+3. Look at the code paths to explain what each choice means
+
+This context can help the user make an informed decision.
+`;
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: guidance,
+      },
+    ],
+    structuredContent: {
+      success: true,
+      requiresUserInput: true,
+      flagName,
+      targetFiles: files,
+      nextStep: 'Ask user which path to preserve using AskUserQuestion tool',
+    },
+  };
+}
+
+/**
+ * Build complete cleanup guidance document
+ */
+function buildCleanupGuidance(
+  flagName: string,
+  preservePath: PreservePath,
+  cleanupInstructions: string,
+  importGuidance: string,
+  files?: string[]
+): string {
+  const scope = files && files.length > 0
+    ? `in ${files.length} specific file(s)`
+    : 'across the codebase';
+
+  const pathEmoji = preservePath === 'enabled' ? '✅' : '❌';
+  const preserveDescription = preservePath === 'enabled'
+    ? 'the code runs as if the flag is **always enabled**'
+    : 'the code runs as if the flag is **always disabled**';
+
+  return `# Feature Flag Cleanup: "${flagName}"
+
+## Summary
+
+You are removing the feature flag **"${flagName}"** ${scope}.
+
+**Preserve Path**: ${pathEmoji} **${preservePath.toUpperCase()}**
+
+This means ${preserveDescription}.
+
+---
+
+${cleanupInstructions}
+
+${importGuidance}
+
+---
+
+## Final Reminder
+
+After completing the cleanup:
+1. **Verify**: Search again to confirm no references remain
+2. **Test**: Run tests to ensure functionality is preserved
+3. **Review**: Check complex cases manually
+4. **Report**: Provide a summary of files changed and any issues found
+
+**Remember**: You're preserving the **${preservePath}** path and removing the **${preservePath === 'enabled' ? 'disabled' : 'enabled'}** path.
+
+Good luck! Take your time and be thorough. 🧹
+`;
+}
+
+/**
+ * Tool definition for MCP server registration
+ */
+export const cleanupFlagTool = {
+  name: 'cleanup_flag',
+  description: `Remove a feature flag from the codebase while preserving the desired code path.
+
+This tool provides comprehensive step-by-step instructions for safely removing feature flag code.
+It guides you through:
+- Finding all flag occurrences using Grep
+- Identifying different flag usage patterns (if-else, ternary, guards, etc.)
+- Removing flag checks while preserving the correct code path
+- Cleaning up unused imports and dead code
+- Verifying and testing the changes
+
+**When to use this tool**:
+- After a feature flag has been rolled out to 100% and is no longer needed
+- When deprecating an experimental feature (preserve disabled path)
+- When cleaning up technical debt from old flags
+- After a kill switch is no longer necessary
+
+**Preserve Path Options**:
+- "enabled": Keep code that runs when flag is true (most common for successful feature rollouts)
+- "disabled": Keep code that runs when flag is false (for removed experiments or kill switches)
+- If not provided: You will be instructed to ask the user which path to preserve
+
+**Workflow**:
+1. Call this tool with the flag name (optionally specify which path to preserve)
+2. If preservePath not provided, you'll be instructed to ask the user via AskUserQuestion tool
+3. Follow the returned instructions to search and remove flag code
+4. Clean up imports and test the changes
+5. Report summary of changes
+
+**Safety Features**:
+- Comprehensive pattern identification (handles if-else, ternary, guards, etc.)
+- Language-agnostic guidance
+- Post-cleanup verification steps
+- Test execution reminders
+- Import cleanup guidance
+
+This tool is inspired by the Unleash AI flag cleanup workflow used in production.
+See: https://github.com/Unleash/unleash/blob/main/.github/workflows/ai-flag-cleanup-pr.yml`,
+  inputSchema: {
+    type: 'object',
+    properties: {
+      flagName: {
+        type: 'string',
+        description: 'Name of the feature flag to remove (e.g., "new-checkout-flow")',
+      },
+      preservePath: {
+        type: 'string',
+        enum: ['enabled', 'disabled'],
+        description:
+          'Optional: Which code path to preserve: "enabled" = keep code that runs when flag is true (typical for rollouts), "disabled" = keep code that runs when flag is false (for removed features). If not provided, you will be instructed to ask the user.',
+      },
+      files: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Optional: Specific files to clean up. If not provided, searches entire codebase. Useful for partial cleanup or when you already know which files contain the flag.',
+      },
+      language: {
+        type: 'string',
+        description:
+          'Optional: Programming language for specialized guidance (e.g., "typescript", "python", "go"). Auto-detected from files if not provided.',
+      },
+    },
+    required: ['flagName'],
+  },
+};


### PR DESCRIPTION
## Summary

Adds a new `cleanup_flag` tool that guides users through safely removing feature flag code from their codebase while preserving the desired code path.

This tool follows the instruction-based pattern (like `wrap_change` and `detect_flag`) and is inspired by the [Unleash AI flag cleanup workflow](https://github.com/Unleash/unleash/blob/main/.github/workflows/ai-flag-cleanup-pr.yml).

## What's New

- **New tool**: `cleanup_flag` - Remove feature flags while preserving enabled or disabled code paths
- **Smart user prompts**: If preserve path not specified, instructs LLM to ask user which path to keep
- **Comprehensive guidance**: Step-by-step instructions for finding and removing flag code
- **Pattern detection**: Handles 7+ common flag patterns (if-else, ternary, guards, JSX, etc.)
- **Language-agnostic**: Works across all supported languages with language-specific examples

## Usage

```typescript
// Option 1: Specify which path to preserve
cleanup_flag({
  flagName: "new-checkout-flow",
  preservePath: "enabled"  // Keep the code that runs when flag is true
})

// Option 2: Let LLM ask the user
cleanup_flag({
  flagName: "experimental-feature"
  // LLM will be instructed to ask user which path to preserve
})
```

## Workflow Integration

The complete feature flag lifecycle is now:
1. `evaluate_change` → Assess risk
2. `detect_flag` → Check for existing flags
3. `create_flag` → Create new flag if needed
4. `wrap_change` → Add flag to code
5. **`cleanup_flag`** → Remove flag after rollout ✨

## Implementation Details

- **Files created**:
  - `src/tools/cleanupFlag.ts` - Main tool implementation
  - `src/templates/cleanupGuidance.ts` - Cleanup instruction generator
- **Files updated**:
  - `src/index.ts` - Register new tool and update instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>