### PR TITLE
feat: flag control

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,15 @@ This MCP server provides tools that integrate with the Unleash Admin API, allowi
 
 ### Current Implementation
 
-- `create_flag` tool for creating flags via Admin API
-- `evaluate_change` tool for determining when flags are needed
-- `detect_flag` tool for discovering existing flags to prevent duplicates
-- `wrap_change` tool for instructing the LLM how to wrap the change based on current code base patterns
+- `create_flag` creates flags via the Admin API
+- `evaluate_change` scores risk and recommends flag usage
+- `detect_flag` discovers existing flags to prevent duplicates
+- `wrap_change` guides the LLM on how to guard code paths
+- `set_flag_rollout` configures flexible rollouts (does not enable environments)
+- `get_flag_state` surfaces feature metadata and environment strategies
+- `toggle_flag_environment` enables or disables environments on demand
+- `remove_flag_strategy` deletes strategies from an environment
+- `cleanup_flag` generates guided instructions for safely removing flagged code paths
 
 ## Installation
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import { wrapChange, wrapChangeTool } from './tools/wrapChange.js';
 import { detectFlag, detectFlagTool } from './tools/detectFlag.js';
 import { setFlagRollout, setFlagRolloutTool } from './tools/setFlagRollout.js';
 import { getFlagState, getFlagStateTool } from './tools/getFlagState.js';
+import { toggleFlagEnvironment, toggleFlagEnvironmentTool } from './tools/toggleFlagEnvironment.js';
 import { VERSION } from './version.js';
 import {
   isProjectsUri,
@@ -124,6 +125,7 @@ async function main(): Promise<void> {
         wrapChangeTool,
         setFlagRolloutTool,
         getFlagStateTool,
+        toggleFlagEnvironmentTool,
       ],
     };
   });
@@ -196,6 +198,13 @@ async function main(): Promise<void> {
 
         case 'get_flag_state':
           return await getFlagState(context, args, request.params._meta?.progressToken);
+
+        case 'toggle_flag_environment':
+          return await toggleFlagEnvironment(
+            context,
+            args,
+            request.params._meta?.progressToken
+          );
 
         default:
           throw new Error(`Unknown tool: ${name}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import { detectFlag, detectFlagTool } from './tools/detectFlag.js';
 import { setFlagRollout, setFlagRolloutTool } from './tools/setFlagRollout.js';
 import { getFlagState, getFlagStateTool } from './tools/getFlagState.js';
 import { toggleFlagEnvironment, toggleFlagEnvironmentTool } from './tools/toggleFlagEnvironment.js';
+import { removeFlagStrategy, removeFlagStrategyTool } from './tools/removeFlagStrategy.js';
 import { VERSION } from './version.js';
 import {
   isProjectsUri,
@@ -126,6 +127,7 @@ async function main(): Promise<void> {
         setFlagRolloutTool,
         getFlagStateTool,
         toggleFlagEnvironmentTool,
+        removeFlagStrategyTool,
       ],
     };
   });
@@ -205,6 +207,9 @@ async function main(): Promise<void> {
             args,
             request.params._meta?.progressToken
           );
+
+        case 'remove_flag_strategy':
+          return await removeFlagStrategy(context, args, request.params._meta?.progressToken);
 
         default:
           throw new Error(`Unknown tool: ${name}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ import { createFlag, createFlagTool } from './tools/createFlag.js';
 import { evaluateChange, evaluateChangeTool } from './tools/evaluateChange.js';
 import { wrapChange, wrapChangeTool } from './tools/wrapChange.js';
 import { detectFlag, detectFlagTool } from './tools/detectFlag.js';
+import { setFlagRollout, setFlagRolloutTool } from './tools/setFlagRollout.js';
 import { VERSION } from './version.js';
 import {
   isProjectsUri,
@@ -115,7 +116,13 @@ async function main(): Promise<void> {
   // Register tool handlers
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     return {
-      tools: [createFlagTool, evaluateChangeTool, detectFlagTool, wrapChangeTool],
+      tools: [
+        createFlagTool,
+        evaluateChangeTool,
+        detectFlagTool,
+        wrapChangeTool,
+        setFlagRolloutTool,
+      ],
     };
   });
 
@@ -181,6 +188,9 @@ async function main(): Promise<void> {
 
         case 'wrap_change':
           return await wrapChange(context, args);
+
+        case 'set_flag_rollout':
+          return await setFlagRollout(context, args, request.params._meta?.progressToken);
 
         default:
           throw new Error(`Unknown tool: ${name}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ import { evaluateChange, evaluateChangeTool } from './tools/evaluateChange.js';
 import { wrapChange, wrapChangeTool } from './tools/wrapChange.js';
 import { detectFlag, detectFlagTool } from './tools/detectFlag.js';
 import { setFlagRollout, setFlagRolloutTool } from './tools/setFlagRollout.js';
+import { getFlagState, getFlagStateTool } from './tools/getFlagState.js';
 import { VERSION } from './version.js';
 import {
   isProjectsUri,
@@ -122,6 +123,7 @@ async function main(): Promise<void> {
         detectFlagTool,
         wrapChangeTool,
         setFlagRolloutTool,
+        getFlagStateTool,
       ],
     };
   });
@@ -191,6 +193,9 @@ async function main(): Promise<void> {
 
         case 'set_flag_rollout':
           return await setFlagRollout(context, args, request.params._meta?.progressToken);
+
+        case 'get_flag_state':
+          return await getFlagState(context, args, request.params._meta?.progressToken);
 
         default:
           throw new Error(`Unknown tool: ${name}`);

--- a/src/tools/getFlagState.ts
+++ b/src/tools/getFlagState.ts
@@ -1,0 +1,155 @@
+import { z } from 'zod';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { ServerContext, ensureProjectId, handleToolError } from '../context.js';
+import { notifyProgress, createFlagResourceLink } from '../utils/streaming.js';
+import { FeatureDetails, FeatureEnvironment } from '../unleash/client.js';
+
+const getFlagStateSchema = z.object({
+  projectId: z
+    .string()
+    .optional()
+    .describe('Project ID (optional if UNLEASH_DEFAULT_PROJECT is configured)'),
+  featureName: z.string().min(1).describe('Feature flag name'),
+  environment: z
+    .string()
+    .optional()
+    .describe('Optional environment filter to focus on a single environment'),
+});
+
+type GetFlagStateInput = z.infer<typeof getFlagStateSchema>;
+
+function summarizeEnvironment(env: FeatureEnvironment): string {
+  const status = env.enabled ? 'enabled' : 'disabled';
+  const strategyCount = env.strategies?.length ?? 0;
+  const enabledStrategies = env.strategies?.filter((s) => !s.disabled).length ?? 0;
+  const variants = env.variants?.length ?? 0;
+  return `${env.environment ?? env.name}: ${status} (${enabledStrategies}/${strategyCount} active strategies${variants ? `, ${variants} variants` : ''})`;
+}
+
+export async function getFlagState(
+  context: ServerContext,
+  args: unknown,
+  progressToken?: string | number
+): Promise<CallToolResult> {
+  try {
+    const input: GetFlagStateInput = getFlagStateSchema.parse(args);
+
+    const projectId = ensureProjectId(input.projectId, context.config.unleash.defaultProject);
+
+    await notifyProgress(
+      context.server,
+      progressToken,
+      0,
+      100,
+      `Fetching feature "${input.featureName}" in project "${projectId}"...`
+    );
+
+    const feature = await context.unleashClient.getFeature(projectId, input.featureName);
+
+    let environments = feature.environments ?? [];
+
+    if (input.environment) {
+      environments = environments.filter(
+        (env) =>
+          env.environment?.toLowerCase() === input.environment!.toLowerCase() ||
+          env.name.toLowerCase() === input.environment!.toLowerCase()
+      );
+    }
+
+    await notifyProgress(
+      context.server,
+      progressToken,
+      100,
+      100,
+      `Fetched feature "${input.featureName}" (${environments.length} environment${environments.length === 1 ? '' : 's'} considered)`
+    );
+
+    const { url, resource } = createFlagResourceLink(
+      context.config.unleash.baseUrl,
+      projectId,
+      input.featureName
+    );
+
+    const apiUrl = `${context.config.unleash.baseUrl}/api/admin/projects/${encodeURIComponent(
+      projectId
+    )}/features/${encodeURIComponent(input.featureName)}`;
+
+    const environmentSummaries =
+      environments.length > 0
+        ? environments.map((env) => `- ${summarizeEnvironment(env)}`).join('\n')
+        : '- No environments matched the provided filters.';
+
+    const messageLines = [
+      `Feature "${feature.name}" (${feature.type ?? 'unknown type'})`,
+      `Enabled: ${feature.enabled ? 'yes' : 'no'} • Archived: ${feature.archived ? 'yes' : 'no'} • Impression data: ${feature.impressionData ? 'on' : 'off'}`,
+      `Project: ${feature.project ?? projectId}`,
+      `Environments:\n${environmentSummaries}`,
+      `View feature: ${url}`,
+      `Admin API: ${apiUrl}`,
+    ];
+
+    const summaryText = messageLines.join('\n');
+
+    context.logger.info(
+      `Retrieved feature state for "${input.featureName}"${input.environment ? ` (filtered to "${input.environment}")` : ''}`
+    );
+
+    const structuredContent = {
+      success: true,
+      projectId,
+      featureName: feature.name,
+      environmentFilter: input.environment,
+      feature: feature as FeatureDetails,
+      environments,
+      links: {
+        ui: url,
+        api: apiUrl,
+        resourceUri: resource.uri,
+      },
+    };
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: summaryText,
+        },
+        {
+          type: 'resource_link',
+          name: feature.name,
+          uri: resource.uri,
+          mimeType: resource.mimeType,
+          text: resource.text,
+        },
+      ],
+      structuredContent,
+    };
+  } catch (error) {
+    return handleToolError(context, error, 'get_flag_state');
+  }
+}
+
+export const getFlagStateTool = {
+  name: 'get_flag_state',
+  description:
+    'Fetch the current feature flag metadata and environment strategies from the Unleash Admin API.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      projectId: {
+        type: 'string',
+        description:
+          'Project ID where the feature flag resides (optional if UNLEASH_DEFAULT_PROJECT is set)',
+      },
+      featureName: {
+        type: 'string',
+        description: 'Feature flag name',
+      },
+      environment: {
+        type: 'string',
+        description: 'Optional environment filter (case-insensitive)',
+      },
+    },
+    required: ['featureName'],
+  },
+};

--- a/src/tools/removeFlagStrategy.ts
+++ b/src/tools/removeFlagStrategy.ts
@@ -1,0 +1,150 @@
+import { z } from 'zod';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { ServerContext, ensureProjectId, handleToolError } from '../context.js';
+import { notifyProgress, createFlagResourceLink } from '../utils/streaming.js';
+import { FeatureDetails } from '../unleash/client.js';
+
+const removeFlagStrategySchema = z.object({
+  projectId: z
+    .string()
+    .optional()
+    .describe('Project ID where the feature flag resides (optional if UNLEASH_DEFAULT_PROJECT is set)'),
+  featureName: z.string().min(1).describe('Feature flag name'),
+  environment: z.string().min(1).describe('Environment from which to remove the strategy'),
+  strategyId: z.string().min(1).describe('ID of the strategy to remove'),
+});
+
+type RemoveFlagStrategyInput = z.infer<typeof removeFlagStrategySchema>;
+
+export async function removeFlagStrategy(
+  context: ServerContext,
+  args: unknown,
+  progressToken?: string | number
+): Promise<CallToolResult> {
+  try {
+    const input: RemoveFlagStrategyInput = removeFlagStrategySchema.parse(args);
+
+    const projectId = ensureProjectId(input.projectId, context.config.unleash.defaultProject);
+
+    await notifyProgress(
+      context.server,
+      progressToken,
+      0,
+      100,
+      `Removing strategy "${input.strategyId}" from "${input.featureName}" in "${input.environment}"...`
+    );
+
+    await context.unleashClient.deleteFeatureStrategy(
+      projectId,
+      input.featureName,
+      input.environment,
+      input.strategyId
+    );
+
+    const feature: FeatureDetails = await context.unleashClient.getFeature(
+      projectId,
+      input.featureName
+    );
+
+    await notifyProgress(
+      context.server,
+      progressToken,
+      100,
+      100,
+      `Removed strategy "${input.strategyId}" from "${input.featureName}" in "${input.environment}".`
+    );
+
+    const matchingEnvironment =
+      feature.environments?.find((env) => {
+        const target = input.environment.toLowerCase();
+        return (
+          env.environment?.toLowerCase() === target || env.name.toLowerCase() === target
+        );
+      }) ?? null;
+
+    const remainingStrategies = matchingEnvironment?.strategies?.length ?? 0;
+
+    const { url, resource } = createFlagResourceLink(
+      context.config.unleash.baseUrl,
+      projectId,
+      input.featureName
+    );
+
+    const apiUrl = `${context.config.unleash.baseUrl}/api/admin/projects/${encodeURIComponent(
+      projectId
+    )}/features/${encodeURIComponent(input.featureName)}/environments/${encodeURIComponent(
+      input.environment
+    )}/strategies/${encodeURIComponent(input.strategyId)}`;
+
+    const messageLines = [
+      `Removed strategy "${input.strategyId}" from "${input.featureName}" in "${input.environment}".`,
+      `Remaining strategies in environment: ${remainingStrategies}`,
+      `View feature: ${url}`,
+      `Delete endpoint (used): ${apiUrl}`,
+    ];
+
+    const structuredContent = {
+      success: true,
+      dryRun: context.config.server.dryRun,
+      projectId,
+      featureName: feature.name,
+      environment: input.environment,
+      removedStrategyId: input.strategyId,
+      remainingStrategies,
+      feature,
+      links: {
+        ui: url,
+        api: apiUrl,
+        resourceUri: resource.uri,
+      },
+    };
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: messageLines.join('\n'),
+        },
+        {
+          type: 'resource_link',
+          name: feature.name,
+          uri: resource.uri,
+          mimeType: resource.mimeType,
+          text: resource.text,
+        },
+      ],
+      structuredContent,
+    };
+  } catch (error) {
+    return handleToolError(context, error, 'remove_flag_strategy');
+  }
+}
+
+export const removeFlagStrategyTool = {
+  name: 'remove_flag_strategy',
+  description:
+    'Delete a strategy configuration from a feature flag environment. Use get_flag_state to discover strategy IDs before removal.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      projectId: {
+        type: 'string',
+        description:
+          'Project ID where the feature flag resides (optional if UNLEASH_DEFAULT_PROJECT is set)',
+      },
+      featureName: {
+        type: 'string',
+        description: 'Feature flag name',
+      },
+      environment: {
+        type: 'string',
+        description: 'Environment from which to remove the strategy',
+      },
+      strategyId: {
+        type: 'string',
+        description: 'ID of the strategy to remove',
+      },
+    },
+    required: ['featureName', 'environment', 'strategyId'],
+  },
+};

--- a/src/tools/setFlagRollout.ts
+++ b/src/tools/setFlagRollout.ts
@@ -166,7 +166,7 @@ export async function setFlagRollout(
 
 export const setFlagRolloutTool = {
   name: 'set_flag_rollout',
-  description: `Configure a flexibleRollout strategy for a feature flag environment with an optional rollout percentage and variants.`,
+  description: `Configure or update a flexibleRollout strategy for a feature flag environment with an optional rollout percentage and variants. This does NOT enable the feature; call toggle_flag_environment to turn environments on or off.`,
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/tools/setFlagRollout.ts
+++ b/src/tools/setFlagRollout.ts
@@ -1,0 +1,234 @@
+import { z } from 'zod';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { ServerContext, ensureProjectId, handleToolError } from '../context.js';
+import { notifyProgress, createFlagResourceLink } from '../utils/streaming.js';
+import { StrategyVariant, StrategyVariantPayload } from '../unleash/client.js';
+
+const variantPayloadSchema = z.object({
+  type: z.enum(['json', 'csv', 'string', 'number']).describe('Payload type'),
+  value: z.string().min(1).describe('Serialized payload value'),
+}) satisfies z.ZodType<StrategyVariantPayload>;
+
+const variantSchema = z
+  .object({
+    name: z.string().min(1).describe('Variant name (unique within this feature)'),
+    weight: z.number().int().min(0).max(1000).describe('Variant weight (0-1000)'),
+    weightType: z.enum(['variable', 'fix']).optional().describe('Variant weight type'),
+    stickiness: z
+      .string()
+      .min(1)
+      .optional()
+      .describe('Stickiness to use for this variant (defaults to "default")'),
+    payload: variantPayloadSchema.optional(),
+  })
+  .describe('Strategy-level variant definition');
+
+const setFlagRolloutSchema = z.object({
+  projectId: z
+    .string()
+    .optional()
+    .describe('Project ID (optional if UNLEASH_DEFAULT_PROJECT is configured)'),
+  featureName: z.string().min(1).describe('Feature flag name'),
+  environment: z.string().min(1).describe('Environment name'),
+  rolloutPercentage: z
+    .number()
+    .min(0)
+    .max(100)
+    .describe('Rollout percentage (0-100) for the flexibleRollout strategy'),
+  groupId: z
+    .string()
+    .optional()
+    .describe('Group ID for stickiness bucketing (defaults to feature name)'),
+  stickiness: z
+    .string()
+    .optional()
+    .describe('Stickiness field (defaults to "default")'),
+  title: z
+    .string()
+    .optional()
+    .describe('Optional descriptive title for the strategy'),
+  disabled: z
+    .boolean()
+    .optional()
+    .describe('Whether to disable the strategy (defaults to false)'),
+  variants: z
+    .array(variantSchema)
+    .optional()
+    .describe('Optional list of strategy-level variants'),
+});
+
+type SetFlagRolloutInput = z.infer<typeof setFlagRolloutSchema>;
+
+export async function setFlagRollout(
+  context: ServerContext,
+  args: unknown,
+  progressToken?: string | number
+): Promise<CallToolResult> {
+  try {
+    const input: SetFlagRolloutInput = setFlagRolloutSchema.parse(args);
+
+    const projectId = ensureProjectId(input.projectId, context.config.unleash.defaultProject);
+
+    const rolloutDisplay = `${input.rolloutPercentage}%`;
+    const mode = context.config.server.dryRun ? '[DRY RUN] ' : '';
+
+    await notifyProgress(
+      context.server,
+      progressToken,
+      0,
+      100,
+      `${mode}Configuring flexibleRollout strategy for "${input.featureName}" (${rolloutDisplay})...`
+    );
+
+    const variants: StrategyVariant[] | undefined = input.variants?.map((variant) => ({
+      name: variant.name,
+      weight: variant.weight,
+      weightType: variant.weightType ?? 'variable',
+      stickiness: variant.stickiness ?? 'default',
+      ...(variant.payload ? { payload: variant.payload } : {}),
+    }));
+
+    const strategy = await context.unleashClient.setFlexibleRolloutStrategy(
+      projectId,
+      input.featureName,
+      input.environment,
+      {
+        rolloutPercentage: input.rolloutPercentage,
+        groupId: input.groupId,
+        stickiness: input.stickiness,
+        title: input.title,
+        disabled: input.disabled,
+        variants,
+      }
+    );
+
+    await notifyProgress(
+      context.server,
+      progressToken,
+      100,
+      100,
+      `${mode}Strategy configured for "${input.featureName}" in "${input.environment}"`
+    );
+
+    const { url, resource } = createFlagResourceLink(
+      context.config.unleash.baseUrl,
+      projectId,
+      input.featureName
+    );
+
+    const apiUrl = `${context.config.unleash.baseUrl}/api/admin/projects/${encodeURIComponent(
+      projectId
+    )}/features/${encodeURIComponent(input.featureName)}/environments/${encodeURIComponent(
+      input.environment
+    )}/strategies`;
+
+    const message = context.config.server.dryRun
+      ? `[DRY RUN] Would configure flexibleRollout strategy for "${input.featureName}" in "${input.environment}" at ${rolloutDisplay}.`
+      : `Configured flexibleRollout strategy for "${input.featureName}" in "${input.environment}" at ${rolloutDisplay}.`;
+
+    context.logger.info(
+      `${message}${input.disabled ? ' Strategy is marked as disabled.' : ''}`
+    );
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `${message}\nView feature: ${url}\nAdmin API: ${apiUrl}`,
+        },
+        {
+          type: 'resource_link',
+          name: input.featureName,
+          uri: resource.uri,
+          mimeType: resource.mimeType,
+          text: resource.text,
+        },
+      ],
+      structuredContent: {
+        success: true,
+        dryRun: context.config.server.dryRun,
+        projectId,
+        featureName: input.featureName,
+        environment: input.environment,
+        rolloutPercentage: input.rolloutPercentage,
+        strategy,
+        links: {
+          ui: url,
+          api: apiUrl,
+          resourceUri: resource.uri,
+        },
+      },
+    };
+  } catch (error) {
+    return handleToolError(context, error, 'set_flag_rollout');
+  }
+}
+
+export const setFlagRolloutTool = {
+  name: 'set_flag_rollout',
+  description: `Configure a flexibleRollout strategy for a feature flag environment with an optional rollout percentage and variants.`,
+  inputSchema: {
+    type: 'object',
+    properties: {
+      projectId: {
+        type: 'string',
+        description:
+          'Project ID where the feature flag resides (optional if UNLEASH_DEFAULT_PROJECT is set)',
+      },
+      featureName: {
+        type: 'string',
+        description: 'Feature flag name',
+      },
+      environment: {
+        type: 'string',
+        description: 'Target environment',
+      },
+      rolloutPercentage: {
+        type: 'number',
+        description: 'Rollout percentage (0-100)',
+      },
+      groupId: {
+        type: 'string',
+        description: 'Group ID for stickiness bucketing (defaults to the feature name)',
+      },
+      stickiness: {
+        type: 'string',
+        description: 'Stickiness field (defaults to "default")',
+      },
+      title: {
+        type: 'string',
+        description: 'Optional descriptive title for the strategy',
+      },
+      disabled: {
+        type: 'boolean',
+        description: 'Disable the strategy (defaults to false)',
+      },
+      variants: {
+        type: 'array',
+        description: 'Optional list of strategy-level variants',
+        items: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            weight: { type: 'number' },
+            weightType: {
+              type: 'string',
+              enum: ['variable', 'fix'],
+            },
+            stickiness: { type: 'string' },
+            payload: {
+              type: 'object',
+              properties: {
+                type: { type: 'string', enum: ['json', 'csv', 'string', 'number'] },
+                value: { type: 'string' },
+              },
+              required: ['type', 'value'],
+            },
+          },
+          required: ['name', 'weight'],
+        },
+      },
+    },
+    required: ['featureName', 'environment', 'rolloutPercentage'],
+  },
+};

--- a/src/tools/toggleFlagEnvironment.ts
+++ b/src/tools/toggleFlagEnvironment.ts
@@ -1,0 +1,148 @@
+import { z } from 'zod';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { ServerContext, ensureProjectId, handleToolError } from '../context.js';
+import { notifyProgress, createFlagResourceLink } from '../utils/streaming.js';
+import { FeatureDetails } from '../unleash/client.js';
+
+const toggleFlagEnvironmentSchema = z.object({
+  projectId: z
+    .string()
+    .optional()
+    .describe('Project ID where the feature flag resides (optional if UNLEASH_DEFAULT_PROJECT is set)'),
+  featureName: z.string().min(1).describe('Feature flag name'),
+  environment: z.string().min(1).describe('Environment to toggle'),
+  enabled: z.boolean().describe('Set to true to enable the flag, or false to disable it'),
+});
+
+type ToggleFlagEnvironmentInput = z.infer<typeof toggleFlagEnvironmentSchema>;
+
+export async function toggleFlagEnvironment(
+  context: ServerContext,
+  args: unknown,
+  progressToken?: string | number
+): Promise<CallToolResult> {
+  try {
+    const input: ToggleFlagEnvironmentInput = toggleFlagEnvironmentSchema.parse(args);
+
+    const projectId = ensureProjectId(input.projectId, context.config.unleash.defaultProject);
+    const action = input.enabled ? 'Enabling' : 'Disabling';
+
+    await notifyProgress(
+      context.server,
+      progressToken,
+      0,
+      100,
+      `${action} "${input.featureName}" in "${input.environment}"...`
+    );
+
+    const feature: FeatureDetails = await context.unleashClient.toggleFeatureEnvironment(
+      projectId,
+      input.featureName,
+      input.environment,
+      input.enabled
+    );
+
+    await notifyProgress(
+      context.server,
+      progressToken,
+      100,
+      100,
+      `${input.enabled ? 'Enabled' : 'Disabled'} "${input.featureName}" in "${input.environment}"`
+    );
+
+    const { url, resource } = createFlagResourceLink(
+      context.config.unleash.baseUrl,
+      projectId,
+      input.featureName
+    );
+
+    const apiBase = `${context.config.unleash.baseUrl}/api/admin/projects/${encodeURIComponent(
+      projectId
+    )}/features/${encodeURIComponent(input.featureName)}/environments/${encodeURIComponent(
+      input.environment
+    )}`;
+    const apiUrl = `${apiBase}/${input.enabled ? 'on' : 'off'}`;
+
+    const environmentState =
+      feature.environments?.find((env) => {
+        const target = input.environment.toLowerCase();
+        return (
+          env.environment?.toLowerCase() === target || env.name.toLowerCase() === target
+        );
+      }) ?? null;
+
+    const messageLines = [
+      `${input.enabled ? 'Enabled' : 'Disabled'} "${input.featureName}" in "${input.environment}".`,
+      environmentState
+        ? `Environment state: ${environmentState.enabled ? 'enabled' : 'disabled'} • Strategies: ${
+            environmentState.strategies?.length ?? 0
+          }`
+        : 'Environment state could not be located in the response.',
+      `View feature: ${url}`,
+      `Admin API: ${apiUrl}`,
+    ];
+
+    const structuredContent = {
+      success: true,
+      dryRun: context.config.server.dryRun,
+      projectId,
+      featureName: feature.name,
+      environment: input.environment,
+      enabled: environmentState?.enabled ?? input.enabled,
+      feature,
+      links: {
+        ui: url,
+        api: apiUrl,
+        resourceUri: resource.uri,
+      },
+    };
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: messageLines.join('\n'),
+        },
+        {
+          type: 'resource_link',
+          name: feature.name,
+          uri: resource.uri,
+          mimeType: resource.mimeType,
+          text: resource.text,
+        },
+      ],
+      structuredContent,
+    };
+  } catch (error) {
+    return handleToolError(context, error, 'toggle_flag_environment');
+  }
+}
+
+export const toggleFlagEnvironmentTool = {
+  name: 'toggle_flag_environment',
+  description:
+    'Enable or disable a feature flag in a specific environment using the Unleash Admin API. For gradual rollouts, configure a flexibleRollout strategy first via set_flag_rollout.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      projectId: {
+        type: 'string',
+        description:
+          'Project ID where the feature flag resides (optional if UNLEASH_DEFAULT_PROJECT is set)',
+      },
+      featureName: {
+        type: 'string',
+        description: 'Feature flag name',
+      },
+      environment: {
+        type: 'string',
+        description: 'Environment to toggle',
+      },
+      enabled: {
+        type: 'boolean',
+        description: 'Set to true to enable the flag, or false to disable it',
+      },
+    },
+    required: ['featureName', 'environment', 'enabled'],
+  },
+};


### PR DESCRIPTION
## About the changes
This is a bit of a big PR but each commit should have an incremental step (I can split in multiple PRs if needed). But 

### Tooling Overview

  - create_flag: Validates inputs and creates a new feature flag, returning UI/API links plus
    structured details.
  - set_flag_rollout: Configures or updates a flexibleRollout strategy (percentage, stickiness,
    optional variants) without enabling the environment.
  - get_flag_state: Fetches full feature metadata, including per-environment status,
    strategies, and variants, with optional environment filtering.
  - toggle_flag_environment: Enables or disables a feature flag in an environment; pairs with
    set_flag_rollout for gradual exposure.
  - remove_flag_strategy: Deletes a specific strategy from an environment and returns updated
    state for verification.