### PR TITLE
Fix: feature flag URI 

### DIFF
--- a/src/utils/streaming.ts
+++ b/src/utils/streaming.ts
@@ -55,7 +55,7 @@ export function createFlagResourceLink(
   return {
     url,
     resource: {
-      uri: `unleash://feature-flag/${projectId}/${flagName}`,
+      uri: `unleash://projects/${projectId}/feature-flags/${flagName}`,
       mimeType: 'application/json',
       text: `Feature flag: ${flagName}`,
     },

--- a/src/utils/streaming.ts
+++ b/src/utils/streaming.ts
@@ -1,4 +1,5 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { buildFeatureFlagUri } from '../resources/unleashResources.js';
 
 /**
  * Helper to emit progress notifications during tool execution.
@@ -55,7 +56,7 @@ export function createFlagResourceLink(
   return {
     url,
     resource: {
-      uri: `unleash://projects/${projectId}/feature-flags/${flagName}`,
+      uri: buildFeatureFlagUri(projectId, flagName),
       mimeType: 'application/json',
       text: `Feature flag: ${flagName}`,
     },


### PR DESCRIPTION
Long story short: we were using the wrong resource URI (`unleash://feature-flag/${projectId}/${flagName}` instead of `unleash://projects/${projectId}/feature-flags/${flagName}`).

I've also:
- handled this resource type in index.ts (including fixing the order to make sure the regex don't overlap)
- added the required utilities to read/parse an individual flag

FYI @gastonfournier 

### How to verify

Run the `get_flag_state` in VS Code (via Copilot), now the flag resource is correctly showed/linked in the UI and you can inspect the raw JSON text.