### PR TITLE
feat: add strategy constraints support to set_flag_rollout

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -387,6 +387,57 @@ Returns a comprehensive markdown document containing:
 
 ---
 
+## Phase 4: Strategy Constraints (Planned)
+
+### Objective
+
+Add `constraints` parameter to `set_flag_rollout` tool for targeting based on context fields.
+
+### Scope
+
+Extend `set_flag_rollout` to accept an optional `constraints` array passed through to the Unleash Admin API.
+
+**Supported Context Fields** (Built-in):
+- `userId`, `sessionId`, `remoteAddress`, `environment`, `appName`, `currentTime`, `properties`
+
+**Note**: Custom context fields (e.g., `country`, `appVersion`) are supported but require Unleash Admin configuration.
+
+### Input Schema
+
+```typescript
+interface StrategyConstraint {
+  contextName: string;                    // e.g., "userId", "appName"
+  operator: ConstraintOperator;           // e.g., "IN", "NOT_IN", "SEMVER_GTE"
+  values?: string[];                      // For IN/NOT_IN
+  value?: string;                         // For single value operators
+}
+```
+
+**Operators**: `IN`, `NOT_IN`, `STR_CONTAINS`, `STR_STARTS_WITH`, `STR_ENDS_WITH`, `NUM_EQ/GT/GTE/LT/LTE`, `SEMVER_EQ/GT/GTE/LT/LTE`
+
+### Example
+
+```json
+{
+  "featureName": "new-feature",
+  "environment": "production",
+  "rolloutPercentage": 100,
+  "constraints": [
+    { "contextName": "userId", "operator": "IN", "values": ["user123", "user456"] }
+  ]
+}
+```
+
+### TODO: Phase 4 Tasks
+
+- [ ] Add `StrategyConstraint` type to `src/unleash/client.ts`
+- [ ] Update `setFlexibleRolloutStrategy` to include constraints in payload
+- [ ] Add constraint schema to `src/tools/setFlagRollout.ts`
+- [ ] Update README with examples
+- [ ] Test against live Unleash instance
+
+---
+
 ## Cross-Phase Tasks
 
 ### Documentation
@@ -451,6 +502,10 @@ Returns a comprehensive markdown document containing:
 - [x] Users can copy-paste snippets directly into their codebase
 - [x] Framework-specific templates for major frameworks
 
+### Phase 4 (Planned)
+- [ ] Constraints parameter working in `set_flag_rollout`
+- [ ] Constraints correctly applied in Unleash dashboard
+
 ### Overall
 - [x] LLM assistants can complete full flag workflow without human intervention
 - [x] Average time to create and wrap a flag: <2 minutes
@@ -488,7 +543,6 @@ Returns a comprehensive markdown document containing:
   - Tag assignment during creation
   - Initial strategy configuration
   - Variant creation
-  - Constraint configuration
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -515,6 +515,63 @@ Returns a comprehensive, markdown-formatted string that guides the user on how t
 [If-block, guard clause, hooks, ternary, etc.]
 ```
 
+### Set flag rollout
+
+The `set_flag_rollout` tool configures a `flexibleRollout` strategy for a feature flag in a specific environment. This includes rollout percentage, stickiness, variants, and constraints for targeting.
+
+#### When to use
+
+Use this tool after creating a feature flag when you want to configure how the flag rolls out to users. This tool does **not** enable the flag; use `toggle_flag_environment` to turn it on.
+
+#### Parameters
+
+- `featureName` (required): The feature flag name.
+- `environment` (required): Target environment (e.g., `development`, `production`).
+- `rolloutPercentage` (required): Percentage of users to receive the feature (0-100).
+- `projectId` (optional): Project ID (defaults to `UNLEASH_DEFAULT_PROJECT`).
+- `groupId` (optional): Group ID for stickiness bucketing (defaults to feature name).
+- `stickiness` (optional): Stickiness field (defaults to `"default"`).
+- `title` (optional): Descriptive title for the strategy.
+- `disabled` (optional): Disable the strategy (defaults to `false`).
+- `variants` (optional): List of strategy-level variants.
+- `constraints` (optional): List of targeting constraints.
+
+#### Constraints
+
+Constraints allow you to target specific users based on context fields. Each constraint has:
+
+- `contextName` (required): Context field name (e.g., `userId`, `environment`).
+- `operator` (required): Comparison operator.
+- `values` (optional): Values for multi-value operators (`IN`, `NOT_IN`).
+- `value` (optional): Single value for single-value operators.
+- `caseInsensitive` (optional): Case insensitive matching.
+- `inverted` (optional): Invert the constraint result.
+
+**Available operators:**
+- Basic: `IN`, `NOT_IN`
+- String: `STR_CONTAINS`, `STR_STARTS_WITH`, `STR_ENDS_WITH`
+- Numeric: `NUM_EQ`, `NUM_GT`, `NUM_GTE`, `NUM_LT`, `NUM_LTE`
+- Semver: `SEMVER_EQ`, `SEMVER_GT`, `SEMVER_GTE`, `SEMVER_LT`, `SEMVER_LTE`
+
+#### Usage example
+
+**Tool payload**
+
+```json
+{
+  "featureName": "new-checkout-flow",
+  "environment": "production",
+  "rolloutPercentage": 50,
+  "constraints": [
+    {
+      "contextName": "userId",
+      "operator": "IN",
+      "values": ["user-123", "user-456"]
+    }
+  ]
+}
+```
+
 ## Architecture
 
 The server follows a focused, purpose-driven design.

--- a/README.md
+++ b/README.md
@@ -551,7 +551,8 @@ Constraints allow you to target specific users based on context fields. Each con
 - Basic: `IN`, `NOT_IN`
 - String: `STR_CONTAINS`, `STR_STARTS_WITH`, `STR_ENDS_WITH`
 - Numeric: `NUM_EQ`, `NUM_GT`, `NUM_GTE`, `NUM_LT`, `NUM_LTE`
-- Semver: `SEMVER_EQ`, `SEMVER_GT`, `SEMVER_GTE`, `SEMVER_LT`, `SEMVER_LTE`
+- Date: `DATE_AFTER`, `DATE_BEFORE`
+- Semver: `SEMVER_EQ`, `SEMVER_GT`, `SEMVER_LT`
 
 #### Usage example
 

--- a/src/tools/setFlagRollout.ts
+++ b/src/tools/setFlagRollout.ts
@@ -38,11 +38,11 @@ const constraintOperatorSchema = z.enum([
   'NUM_GTE',
   'NUM_LT',
   'NUM_LTE',
+  'DATE_AFTER',
+  'DATE_BEFORE',
   'SEMVER_EQ',
   'SEMVER_GT',
-  'SEMVER_GTE',
   'SEMVER_LT',
-  'SEMVER_LTE',
 ]);
 
 const constraintSchema = z

--- a/src/unleash/client.ts
+++ b/src/unleash/client.ts
@@ -84,11 +84,11 @@ export type ConstraintOperator =
   | 'NUM_GTE'
   | 'NUM_LT'
   | 'NUM_LTE'
+  | 'DATE_AFTER'
+  | 'DATE_BEFORE'
   | 'SEMVER_EQ'
   | 'SEMVER_GT'
-  | 'SEMVER_GTE'
-  | 'SEMVER_LT'
-  | 'SEMVER_LTE';
+  | 'SEMVER_LT';
 
 /**
  * Strategy constraint for targeting.
@@ -121,7 +121,7 @@ export interface FeatureStrategy {
   featureName?: string;
   sortOrder?: number;
   segments?: number[];
-  constraints?: Array<Record<string, unknown>>;
+  constraints?: StrategyConstraint[];
   variants?: StrategyVariant[];
   parameters: Record<string, string>;
 }

--- a/src/unleash/client.ts
+++ b/src/unleash/client.ts
@@ -69,6 +69,40 @@ export interface StrategyVariant {
   [key: string]: unknown;
 }
 
+/**
+ * Constraint operators supported by Unleash.
+ * See: https://docs.getunleash.io/reference/activation-strategies
+ */
+export type ConstraintOperator =
+  | 'IN'
+  | 'NOT_IN'
+  | 'STR_CONTAINS'
+  | 'STR_STARTS_WITH'
+  | 'STR_ENDS_WITH'
+  | 'NUM_EQ'
+  | 'NUM_GT'
+  | 'NUM_GTE'
+  | 'NUM_LT'
+  | 'NUM_LTE'
+  | 'SEMVER_EQ'
+  | 'SEMVER_GT'
+  | 'SEMVER_GTE'
+  | 'SEMVER_LT'
+  | 'SEMVER_LTE';
+
+/**
+ * Strategy constraint for targeting.
+ * See: https://docs.getunleash.io/reference/activation-strategies
+ */
+export interface StrategyConstraint {
+  contextName: string;
+  operator: ConstraintOperator;
+  values?: string[];
+  value?: string;
+  caseInsensitive?: boolean;
+  inverted?: boolean;
+}
+
 export interface SetFlagRolloutOptions {
   rolloutPercentage: number;
   groupId?: string;
@@ -76,6 +110,7 @@ export interface SetFlagRolloutOptions {
   title?: string;
   disabled?: boolean;
   variants?: StrategyVariant[];
+  constraints?: StrategyConstraint[];
 }
 
 export interface FeatureStrategy {

--- a/src/unleash/client.ts
+++ b/src/unleash/client.ts
@@ -300,6 +300,9 @@ export class UnleashClient {
       disabled: options.disabled,
       parameters,
       ...(options.variants && options.variants.length > 0 ? { variants: options.variants } : {}),
+      ...(options.constraints && options.constraints.length > 0
+        ? { constraints: options.constraints }
+        : {}),
     };
 
     if (this.dryRun) {
@@ -311,6 +314,7 @@ export class UnleashClient {
         featureName,
         parameters,
         variants: payload.variants ?? [],
+        constraints: payload.constraints ?? [],
       };
     }
 


### PR DESCRIPTION
## Summary

Add support for strategy constraints in `set_flag_rollout` tool, enabling targeting based on context fields like `userId`, `environment`, etc.

### Changes

- Add `ConstraintOperator` type with all 15 operators (IN, NOT_IN, STR_*, NUM_*, SEMVER_*)
- Add `StrategyConstraint` interface for type-safe constraint definitions
- Update `setFlexibleRolloutStrategy` to pass constraints to API
- Add constraint schema to `set_flag_rollout` tool with full validation
- Update README with documentation and usage examples
- Update PRD with Phase 4: Strategy Constraints

### Example Usage

```json
{
  "featureName": "new-checkout-flow",
  "environment": "production",
  "rolloutPercentage": 50,
  "constraints": [
    {
      "contextName": "userId",
      "operator": "IN",
      "values": ["user-123", "user-456"]
    }
  ]
}
```
