### PR TITLE
feat: remote mcp server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,74 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Unleash MCP Server — a Model Context Protocol server for managing Unleash feature flags. It enables LLM-powered coding assistants to create, evaluate, detect, and wrap code changes with feature flags via the Unleash Admin API.
+
+## Commands
+
+```bash
+yarn install          # Install dependencies (uses Yarn 1.x via Corepack)
+yarn build            # Compile TypeScript (tsc) → dist/
+yarn dev              # Run from source with tsx
+yarn lint             # Lint with Biome
+yarn lint:fix         # Lint and auto-fix with Biome
+yarn test             # Run tests with Vitest (currently no test files)
+```
+
+Single test file: `npx vitest run src/path/to/file.test.ts`
+
+## Architecture
+
+This is an MCP server with a dual-mode architecture (stdio + remote HTTP). A transport-agnostic factory (`src/server.ts`) creates the `McpServer` with all tools and resources registered. Two entry points connect different transports:
+
+- **Local (stdio) mode**: `src/index.ts` reads env vars/CLI flags, creates the server with PAT auth, and connects `StdioServerTransport`. This is the CLI entry point (`npx unleash-mcp`).
+- **Embedded (remote) mode**: `src/remote.ts` exports `createMcpHandler()` for embedding inside an HTTP server (e.g. Express). Each request creates a fresh server + `StreamableHTTPServerTransport` pair with forwarded auth headers.
+
+### Package Exports
+
+- `@unleash/mcp` — Default entry (stdio CLI)
+- `@unleash/mcp/server` — `createUnleashMcpServer(options)` factory function
+- `@unleash/mcp/remote` — `createMcpHandler(defaults)` HTTP request handler
+
+### Key Patterns
+
+**Tool registration**: Each tool in `src/tools/` exports a `ToolDefinition` object (`src/tools/types.ts`) with `name`, `description`, `inputSchema` (Zod), and `implementation` function. Tools are registered in a loop in `src/server.ts`. To add a new tool: create a file in `src/tools/`, export a `ToolDefinition`, and add it to the `tools` array in `src/server.ts`.
+
+**Shared context**: All tools receive a `ServerContext` (`src/context.ts`) containing `config`, `unleashClient`, `logger`, and `notifyProgress`. Use `ensureProjectId()` and `handleToolError()` from context for consistent behavior.
+
+**API client**: `src/unleash/client.ts` (`UnleashClient`) wraps the Unleash Admin API using native `fetch`. Constructor takes `(baseUrl, authHeaders, dryRun)` where `authHeaders` is a `Record<string, string>` spread into every request. All methods support `--dry-run` mode by returning mock responses. Errors are thrown as `CustomError` (`src/utils/errors.ts`) with `{code, message, hint}` format.
+
+**Input validation**: All tool inputs are validated with Zod schemas before any API calls.
+
+**Logging**: Never write to stdout (breaks MCP stdio handshake). Use the `Logger` from context which writes to stderr or `APP_LOG_FILE`. The `MCP_STDIO_LOG_FILE` env var tees raw MCP protocol traffic for debugging.
+
+### Module Layout
+
+- `src/server.ts` — Transport-agnostic server factory (`createUnleashMcpServer`)
+- `src/remote.ts` — HTTP request handler (`createMcpHandler`) for embedded mode
+- `src/index.ts` — Stdio CLI entry point
+- `src/tools/` — One file per MCP tool (createFlag, evaluateChange, detectFlag, wrapChange, cleanupFlag, setFlagRollout, getFlagState, toggleFlagEnvironment, removeFlagStrategy)
+- `src/unleash/client.ts` — Unleash Admin API client
+- `src/evaluation/` — Risk assessment and flag detection patterns (used by evaluateChange)
+- `src/detection/` — Flag discovery strategies and scoring (used by detectFlag)
+- `src/templates/` — Language detection, code wrapper templates, search guidance (used by wrapChange)
+- `src/knowledge/` — Unleash best practices knowledge base
+- `src/prompts/` — Markdown prompt formatting utilities
+- `src/resources/` — MCP resource handlers for projects and feature flags
+- `src/utils/` — Error normalization, streaming/progress notifications, stdio logging
+
+## Code Style
+
+Enforced by Biome (config in `biome.json`):
+- 2-space indentation, 100-char line width
+- Single quotes, trailing commas, semicolons
+- Recommended lint rules enabled
+- Import organization via Biome assist
+
+TypeScript strict mode is on with `noUnusedLocals`, `noUnusedParameters`, `noImplicitReturns`, and `noFallthroughCasesInSwitch`.
+
+## Configuration
+
+Required env vars: `UNLEASH_BASE_URL`, `UNLEASH_PAT`. Optional: `UNLEASH_DEFAULT_PROJECT`, `UNLEASH_DEFAULT_ENVIRONMENT`, `LOG_LEVEL`, `APP_LOG_FILE`, `MCP_STDIO_LOG_FILE`. CLI flags: `--dry-run`, `--log-level <level>`. See `.env.example` for reference.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,20 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./server": {
+      "import": "./dist/server.js",
+      "types": "./dist/server.d.ts"
+    },
+    "./remote": {
+      "import": "./dist/remote.js",
+      "types": "./dist/remote.d.ts"
+    }
+  },
   "bin": {
     "unleash-mcp": "dist/index.js"
   },
@@ -31,6 +45,8 @@
   "devDependencies": {
     "@biomejs/biome": "2.3.8",
     "@types/node": "^22.10.2",
+    "@types/supertest": "^6.0.3",
+    "supertest": "^7.2.2",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2",
     "vitest": "^2.1.8"

--- a/package.json
+++ b/package.json
@@ -44,8 +44,10 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.8",
+    "@types/express": "^5.0.6",
     "@types/node": "^22.10.2",
     "@types/supertest": "^6.0.3",
+    "express": "^5.2.1",
     "supertest": "^7.2.2",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2",

--- a/src/config.ts
+++ b/src/config.ts
@@ -86,7 +86,7 @@ export function loadConfig(): Config {
   }
 }
 
-function normalizeBaseUrl(url: string): string {
+export function normalizeBaseUrl(url: string): string {
   try {
     const parsed = new URL(url);
     // Collapse multiple slashes in the path, remove trailing slashes, and preserve root path if pathname becomes empty.

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,8 +1,13 @@
 import fs from 'node:fs';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { Config } from './config.js';
-import type { UnleashClient } from './unleash/client.js';
+import type { FeatureFlagSummary, UnleashClient, UnleashProjectSummary } from './unleash/client.js';
 import { normalizeError } from './utils/errors.js';
+
+export interface ResourceCache {
+  projects: { data: UnleashProjectSummary[]; fetchedAt: number } | null;
+  featureFlags: Map<string, { data: FeatureFlagSummary[]; fetchedAt: number }>;
+}
 
 /**
  * Shared runtime context available to all tools and prompts.
@@ -12,6 +17,7 @@ export interface ServerContext {
   config: Config;
   unleashClient: UnleashClient;
   logger: Logger;
+  cache: ResourceCache;
   notifyProgress: (
     progressToken: string | number | undefined,
     current: number,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,80 +1,17 @@
 #!/usr/bin/env node
 
-/**
- * Unleash MCP Server
- *
- * A purpose-driven Model Context Protocol server for managing Unleash feature flags.
- * This server provides tools for creating feature flags while following Unleash best practices.
- *
- * Phase 1 implements:
- * - create_flag: Create feature flags via the Unleash Admin API
- *
- * Phase 2 implements:
- * - evaluate_change: Prompt to guide when flags are needed
- *
- * Phase 3 implements:
- * - wrap_change: Generate code snippets for flag usage
- *
- * Architecture principles:
- * - Thin, purpose-driven surface area
- * - One file per capability
- * - Shared helpers only where they remove duplication
- * - Explicit validation and error handling
- * - Progress streaming for visibility
- */
-
-import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import type { Variables } from '@modelcontextprotocol/sdk/shared/uriTemplate.js';
-import { UriTemplate } from '@modelcontextprotocol/sdk/shared/uriTemplate.js';
 import { loadConfig } from './config.js';
-import { createLogger, type ServerContext } from './context.js';
-import {
-  extractFlagNameFromFeatureUri,
-  extractProjectIdFromFeatureUri,
-  FEATURE_FLAG_RESOURCE_URI,
-  FEATURE_FLAGS_RESOURCE_TEMPLATE,
-  isFeatureFlagsUri,
-  isFeatureFlagUri,
-  isProjectsUri,
-  PROJECTS_RESOURCE_TEMPLATE,
-  parseFeatureFlagsResourceOptions,
-  parseProjectsResourceOptions,
-  readFeatureFlagResource,
-  readFeatureFlagsResource,
-  readProjectsResource,
-} from './resources/unleashResources.js';
-import { cleanupFlagTool } from './tools/cleanupFlag.js';
-import { createFlagTool } from './tools/createFlag.js';
-import { detectFlagTool } from './tools/detectFlag.js';
-import { evaluateChangeTool } from './tools/evaluateChange.js';
-import { getFlagStateTool } from './tools/getFlagState.js';
-import { removeFlagStrategyTool } from './tools/removeFlagStrategy.js';
-import { setFlagRolloutTool } from './tools/setFlagRollout.js';
-import { toggleFlagEnvironmentTool } from './tools/toggleFlagEnvironment.js';
-import type { ToolDefinition } from './tools/types.js';
-import { wrapChangeTool } from './tools/wrapChange.js';
-import { UnleashClient } from './unleash/client.js';
+import { createLogger } from './context.js';
+import { createUnleashMcpServer } from './server.js';
 import { enableStdioLogging } from './utils/stdioLogging.js';
-import { notifyProgress } from './utils/streaming.js';
 import { VERSION } from './version.js';
 
-class UriTemplateWithMatcher extends UriTemplate {
-  matchFn: (uri: string) => Variables | null;
-
-  constructor(template: string, matchFn: (uri: string) => Variables | null) {
-    super(template);
-    this.matchFn = matchFn;
-  }
-
-  // Override default matching to tolerate missing optional query params.
-  match(uri: string): Variables | null {
-    return this.matchFn(uri);
-  }
-}
-
 /**
- * Main entry point for the MCP server.
+ * Stdio entry point for the Unleash MCP Server.
+ * Reads configuration from environment variables and CLI flags,
+ * creates the MCP server via the shared factory, and connects
+ * a StdioServerTransport.
  */
 async function main(): Promise<void> {
   // Optional diagnostic logging of stdio without modifying protocol flow.
@@ -92,81 +29,15 @@ async function main(): Promise<void> {
     logger.info(`Default project: ${config.unleash.defaultProject}`);
   }
 
-  // Create Unleash Admin API client
-  const unleashClient = new UnleashClient(
-    config.unleash.baseUrl,
-    config.unleash.pat,
-    config.server.dryRun,
-  );
-
-  const instructions = [
-    'Use this tool for local development to increase confidence by decoupling the change from deployments:',
-    '1) Call evaluate_change to get a risk assessment on the current code change.',
-    '2) The evaluate_change tool will automatically call detect_flag to search for existing flags to prevent duplicates.',
-    '3) If an existing flag is found, use it. If the code change is risky and no flag exists, create a feature flag with create_flag.',
-    '4) Use wrap_change to guard code with an Unleash flag.',
-    '5) When a flag is rolled out and ready to be removed, use cleanup_flag to safely remove the flag code while preserving the desired path.',
-  ].join('\n');
-
-  // Create MCP server
-  const server = new McpServer(
-    {
-      name: 'unleash-mcp',
-      version: VERSION,
-      title:
-        'Local development assistant. After making a code change follow this workflow: evaluate_change → create_flag → wrap_change to score risk and steer next steps.',
-    },
-    {
-      capabilities: {
-        tools: {},
-        logging: {},
-        resources: {},
-      },
-      instructions,
-    },
-  );
-
-  // Build shared context
-  const context: ServerContext = {
-    config,
-    unleashClient,
+  const server = createUnleashMcpServer({
+    baseUrl: config.unleash.baseUrl,
+    authHeaders: { Authorization: config.unleash.pat.trim() },
+    defaultProject: config.unleash.defaultProject,
+    defaultEnvironment: config.unleash.defaultEnvironment,
+    dryRun: config.server.dryRun,
+    logLevel: config.server.logLevel,
     logger,
-    notifyProgress: notifyProgress(server),
-  };
-
-  type ProgressExtra = { _meta?: { progressToken?: string | number } };
-
-  const tools: ToolDefinition[] = [
-    createFlagTool,
-    evaluateChangeTool,
-    detectFlagTool,
-    wrapChangeTool,
-    cleanupFlagTool,
-    setFlagRolloutTool,
-    getFlagStateTool,
-    toggleFlagEnvironmentTool,
-    removeFlagStrategyTool,
-  ];
-
-  // this is needed to work around a typing issue in the MCP SDK
-  const registerTool = server.registerTool.bind(server) as (
-    name: string,
-    config: { description?: string; inputSchema?: ToolDefinition['inputSchema'] },
-    cb: (args: unknown, extra: ProgressExtra) => unknown,
-  ) => unknown;
-
-  tools.forEach((tool) => {
-    registerTool(
-      tool.name,
-      {
-        description: tool.description,
-        inputSchema: tool.inputSchema,
-      },
-      (args: unknown, extra: ProgressExtra) =>
-        tool.implementation(context, args, extra._meta?.progressToken),
-    );
   });
-  registerResources(server, context);
 
   // Start server with stdio transport
   const transport = new StdioServerTransport();
@@ -180,103 +51,3 @@ main().catch((error) => {
   console.error('Fatal error starting server:', error);
   process.exit(1);
 });
-
-function registerResources(server: McpServer, context: ServerContext): void {
-  const projectsTemplate = new ResourceTemplate(
-    new UriTemplateWithMatcher(PROJECTS_RESOURCE_TEMPLATE, (uri) =>
-      isProjectsUri(uri) ? {} : null,
-    ),
-    { list: undefined },
-  );
-
-  server.registerResource(
-    'unleash-projects-filtered',
-    projectsTemplate,
-    {
-      mimeType: 'application/json',
-      description:
-        'Unleash projects with optional query parameters. Use limit to control page size, order=asc|desc to sort by creation time, and offset to paginate.',
-    },
-    async (uri: URL, _variables: unknown, _extra: unknown) => ({
-      contents: [await readProjectsResource(context, parseProjectsResourceOptions(uri.toString()))],
-    }),
-  );
-
-  const featureFlagsTemplate = new ResourceTemplate(
-    new UriTemplateWithMatcher(FEATURE_FLAGS_RESOURCE_TEMPLATE, (uri) => {
-      if (!isFeatureFlagsUri(uri)) {
-        return null;
-      }
-
-      const projectId = extractProjectIdFromFeatureUri(uri);
-      return projectId ? { projectId } : null;
-    }),
-    { list: undefined },
-  );
-
-  server.registerResource(
-    'unleash-feature-flags-by-project',
-    featureFlagsTemplate,
-    {
-      mimeType: 'application/json',
-      description:
-        'Feature flags for a specific Unleash project. Replace {projectId}; optional limit/order/offset parameters help paginate flags alphabetically.',
-    },
-    async (uri: URL, variables: any, _extra: unknown) => {
-      const projectId = variables.projectId;
-      if (!projectId) {
-        throw new Error('Project ID missing from feature flags URI');
-      }
-
-      return {
-        contents: [
-          await readFeatureFlagsResource(
-            context,
-            projectId,
-            parseFeatureFlagsResourceOptions(uri.toString()),
-          ),
-        ],
-      };
-    },
-  );
-
-  const featureFlagTemplate = new ResourceTemplate(
-    new UriTemplateWithMatcher(FEATURE_FLAG_RESOURCE_URI, (uri) => {
-      if (!isFeatureFlagUri(uri)) {
-        return null;
-      }
-
-      const projectId = extractProjectIdFromFeatureUri(uri);
-      const flagName = extractFlagNameFromFeatureUri(uri);
-
-      if (!projectId || !flagName) {
-        return null;
-      }
-
-      return { projectId, flagName };
-    }),
-    { list: undefined },
-  );
-
-  server.registerResource(
-    'unleash-feature-flag',
-    featureFlagTemplate,
-    {
-      mimeType: 'application/json',
-      description: 'Single feature flag resource.',
-    },
-    async (_uri: URL, variables: any, _extra: unknown) => {
-      const { projectId, flagName } = variables;
-      if (!projectId) {
-        throw new Error('Project ID missing from feature flag URI');
-      }
-      if (!flagName) {
-        throw new Error('Flag name missing from feature flag URI');
-      }
-
-      return {
-        contents: [await readFeatureFlagResource(context, projectId, flagName)],
-      };
-    },
-  );
-}

--- a/src/remote.e2e.test.ts
+++ b/src/remote.e2e.test.ts
@@ -1,0 +1,127 @@
+import { createServer } from 'node:http';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createMcpHandler } from './remote.js';
+
+/**
+ * E2E test for the remote MCP handler.
+ *
+ * Spins up a real HTTP server with createMcpHandler, sends JSON-RPC requests
+ * via supertest, and verifies the full MCP lifecycle works end-to-end.
+ */
+describe('remote MCP handler (e2e)', () => {
+  const handler = createMcpHandler({
+    baseUrl: 'http://localhost:4242',
+    dryRun: true,
+    logLevel: 'error',
+  });
+
+  const server = createServer(async (req, res) => {
+    await handler(req, res, {
+      authHeaders: { Authorization: 'test-token' },
+      parsedBody: await parseBody(req),
+    });
+  });
+
+  beforeAll(() => new Promise<void>((resolve) => server.listen(0, resolve)));
+  afterAll(
+    () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  );
+
+  function mcpPost(body: unknown) {
+    return request(server)
+      .post('/')
+      .set('Accept', 'application/json, text/event-stream')
+      .set('Content-Type', 'application/json')
+      .send(body);
+  }
+
+  it('handles initialize → tools/list → tools/call roundtrip', async () => {
+    // 1. Initialize
+    const initRes = await mcpPost({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-03-26',
+        capabilities: {},
+        clientInfo: { name: 'test-client', version: '1.0.0' },
+      },
+    }).expect(200);
+
+    expect(initRes.body.result).toBeDefined();
+    expect(initRes.body.result.serverInfo.name).toBe('unleash-mcp');
+    expect(initRes.body.result.capabilities.tools).toBeDefined();
+
+    // 2. List tools (new stateless request — each request is independent)
+    const listRes = await mcpPost([
+      { jsonrpc: '2.0', method: 'notifications/initialized' },
+      { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
+    ]).expect(200);
+
+    const toolsResult = Array.isArray(listRes.body)
+      ? listRes.body.find((r: { id?: number }) => r.id === 2)
+      : listRes.body;
+
+    expect(toolsResult.result.tools).toBeDefined();
+    const toolNames = toolsResult.result.tools.map((t: { name: string }) => t.name);
+    expect(toolNames).toContain('create_flag');
+    expect(toolNames).toContain('evaluate_change');
+    expect(toolNames).toContain('detect_flag');
+    expect(toolNames).toContain('wrap_change');
+    expect(toolNames).toContain('cleanup_flag');
+    expect(toolNames).toContain('set_flag_rollout');
+    expect(toolNames).toContain('get_flag_state');
+    expect(toolNames).toContain('toggle_flag_environment');
+    expect(toolNames).toContain('remove_flag_strategy');
+    expect(toolNames).toHaveLength(9);
+
+    // 3. Call a tool (dry-run create_flag)
+    const callRes = await mcpPost([
+      { jsonrpc: '2.0', method: 'notifications/initialized' },
+      {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: {
+          name: 'create_flag',
+          arguments: {
+            name: 'e2e-test-flag',
+            type: 'release',
+            description: 'Created by e2e test',
+            projectId: 'default',
+          },
+        },
+      },
+    ]).expect(200);
+
+    const callResult = Array.isArray(callRes.body)
+      ? callRes.body.find((r: { id?: number }) => r.id === 3)
+      : callRes.body;
+
+    expect(callResult.result).toBeDefined();
+    expect(callResult.result.isError).toBeFalsy();
+
+    const textContent = callResult.result.content.find((c: { type: string }) => c.type === 'text');
+    expect(textContent.text).toContain('e2e-test-flag');
+    expect(textContent.text).toContain('DRY RUN');
+  });
+});
+
+function parseBody(req: import('node:http').IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString()));
+      } catch (e) {
+        reject(e);
+      }
+    });
+    req.on('error', reject);
+  });
+}

--- a/src/remote.e2e.test.ts
+++ b/src/remote.e2e.test.ts
@@ -25,11 +25,8 @@ describe('remote MCP handler (e2e)', () => {
     });
   });
 
-  function mcpPost(body: unknown) {
-    return request(app)
-      .post('/')
-      .set('Accept', 'application/json, text/event-stream')
-      .send(body);
+  function mcpPost(body: object | object[]) {
+    return request(app).post('/').set('Accept', 'application/json, text/event-stream').send(body);
   }
 
   it('handles initialize → tools/list → tools/call roundtrip', async () => {

--- a/src/remote.e2e.test.ts
+++ b/src/remote.e2e.test.ts
@@ -1,41 +1,34 @@
-import { createServer } from 'node:http';
+import express from 'express';
 import request from 'supertest';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { createMcpHandler } from './remote.js';
 
 /**
  * E2E test for the remote MCP handler.
  *
- * Spins up a real HTTP server with createMcpHandler, sends JSON-RPC requests
+ * Spins up an Express app with createMcpHandler, sends JSON-RPC requests
  * via supertest, and verifies the full MCP lifecycle works end-to-end.
  */
 describe('remote MCP handler (e2e)', () => {
   const handler = createMcpHandler({
-    baseUrl: 'http://localhost:4242', // Unleash admin API URL
-    dryRun: true, // don't hit the above URL
+    baseUrl: 'http://localhost:4242',
+    dryRun: true,
     logLevel: 'error',
   });
 
-  const server = createServer(async (req, res) => {
+  const app = express();
+  app.use(express.json());
+  app.post('/', async (req, res) => {
     await handler(req, res, {
       authHeaders: { Authorization: 'test-token' },
-      parsedBody: await parseBody(req),
+      parsedBody: req.body,
     });
   });
 
-  beforeAll(() => new Promise<void>((resolve) => server.listen(0, resolve)));
-  afterAll(
-    () =>
-      new Promise<void>((resolve, reject) =>
-        server.close((err) => (err ? reject(err) : resolve())),
-      ),
-  );
-
   function mcpPost(body: unknown) {
-    return request(server)
+    return request(app)
       .post('/')
       .set('Accept', 'application/json, text/event-stream')
-      .set('Content-Type', 'application/json')
       .send(body);
   }
 
@@ -113,18 +106,3 @@ describe('remote MCP handler (e2e)', () => {
     });
   });
 });
-
-function parseBody(req: import('node:http').IncomingMessage): Promise<unknown> {
-  return new Promise((resolve, reject) => {
-    const chunks: Buffer[] = [];
-    req.on('data', (chunk: Buffer) => chunks.push(chunk));
-    req.on('end', () => {
-      try {
-        resolve(JSON.parse(Buffer.concat(chunks).toString()));
-      } catch (e) {
-        reject(e);
-      }
-    });
-    req.on('error', reject);
-  });
-}

--- a/src/remote.e2e.test.ts
+++ b/src/remote.e2e.test.ts
@@ -11,8 +11,8 @@ import { createMcpHandler } from './remote.js';
  */
 describe('remote MCP handler (e2e)', () => {
   const handler = createMcpHandler({
-    baseUrl: 'http://localhost:4242',
-    dryRun: true,
+    baseUrl: 'http://localhost:4242', // Unleash admin API URL
+    dryRun: true, // don't hit the above URL
     logLevel: 'error',
   });
 
@@ -66,18 +66,18 @@ describe('remote MCP handler (e2e)', () => {
       ? listRes.body.find((r: { id?: number }) => r.id === 2)
       : listRes.body;
 
-    expect(toolsResult.result.tools).toBeDefined();
-    const toolNames = toolsResult.result.tools.map((t: { name: string }) => t.name);
-    expect(toolNames).toContain('create_flag');
-    expect(toolNames).toContain('evaluate_change');
-    expect(toolNames).toContain('detect_flag');
-    expect(toolNames).toContain('wrap_change');
-    expect(toolNames).toContain('cleanup_flag');
-    expect(toolNames).toContain('set_flag_rollout');
-    expect(toolNames).toContain('get_flag_state');
-    expect(toolNames).toContain('toggle_flag_environment');
-    expect(toolNames).toContain('remove_flag_strategy');
-    expect(toolNames).toHaveLength(9);
+    const toolNames = toolsResult.result.tools.map((t: { name: string }) => t.name).sort();
+    expect(toolNames).toEqual([
+      'cleanup_flag',
+      'create_flag',
+      'detect_flag',
+      'evaluate_change',
+      'get_flag_state',
+      'remove_flag_strategy',
+      'set_flag_rollout',
+      'toggle_flag_environment',
+      'wrap_change',
+    ]);
 
     // 3. Call a tool (dry-run create_flag)
     const callRes = await mcpPost([
@@ -105,9 +105,12 @@ describe('remote MCP handler (e2e)', () => {
     expect(callResult.result).toBeDefined();
     expect(callResult.result.isError).toBeFalsy();
 
-    const textContent = callResult.result.content.find((c: { type: string }) => c.type === 'text');
-    expect(textContent.text).toContain('e2e-test-flag');
-    expect(textContent.text).toContain('DRY RUN');
+    expect(callResult.result).toMatchObject({
+      content: expect.arrayContaining([
+        { type: 'text', text: expect.stringContaining('e2e-test-flag') },
+        { type: 'text', text: expect.stringContaining('DRY RUN') },
+      ]),
+    });
   });
 });
 

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -1,0 +1,49 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { type CreateServerOptions, createUnleashMcpServer } from './server.js';
+
+export type RemoteHandlerOptions = Omit<CreateServerOptions, 'authHeaders'>;
+
+export type McpRequestHandler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  options: { authHeaders: Record<string, string>; parsedBody?: unknown },
+) => Promise<void>;
+
+/**
+ * Create a stateless HTTP request handler for embedding the Unleash MCP server
+ * inside an existing HTTP server (e.g. Express).
+ *
+ * Each request creates a fresh McpServer + StreamableHTTPServerTransport pair.
+ * The caller provides auth headers per request (e.g. forwarded session cookies).
+ *
+ * Usage with Express:
+ * ```typescript
+ * import { createMcpHandler } from '@unleash/mcp/remote';
+ * const handleMcp = createMcpHandler({ baseUrl: 'http://localhost:4242' });
+ * app.post('/api/mcp', async (req, res) => {
+ *   await handleMcp(req, res, { authHeaders: extractAuth(req), parsedBody: req.body });
+ * });
+ * ```
+ */
+export function createMcpHandler(defaults: RemoteHandlerOptions): McpRequestHandler {
+  return async (req, res, options) => {
+    const server = createUnleashMcpServer({
+      ...defaults,
+      authHeaders: options.authHeaders,
+    });
+
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true,
+    });
+
+    res.on('close', () => {
+      transport.close().catch(() => {});
+      server.close().catch(() => {});
+    });
+
+    await server.connect(transport);
+    await transport.handleRequest(req, res, options.parsedBody);
+  };
+}

--- a/src/resources/unleashResources.ts
+++ b/src/resources/unleashResources.ts
@@ -419,19 +419,7 @@ function normalizeOrder(value: string | null): 'asc' | 'desc' | undefined {
 }
 
 const PROJECTS_CACHE_TTL_MS = 60_000;
-let cachedProjects: {
-  data: UnleashProjectSummary[];
-  fetchedAt: number;
-} | null = null;
-
 const FEATURE_FLAGS_CACHE_TTL_MS = 60_000;
-const cachedFeatureFlags = new Map<
-  string,
-  {
-    data: FeatureFlagSummary[];
-    fetchedAt: number;
-  }
->();
 
 async function getCachedProjects(context: ServerContext): Promise<{
   projects: UnleashProjectSummary[];
@@ -439,20 +427,18 @@ async function getCachedProjects(context: ServerContext): Promise<{
   fromCache: boolean;
 }> {
   const now = Date.now();
+  const cached = context.cache.projects;
 
-  if (cachedProjects && now - cachedProjects.fetchedAt < PROJECTS_CACHE_TTL_MS) {
+  if (cached && now - cached.fetchedAt < PROJECTS_CACHE_TTL_MS) {
     return {
-      projects: cachedProjects.data,
-      fetchedAt: cachedProjects.fetchedAt,
+      projects: cached.data,
+      fetchedAt: cached.fetchedAt,
       fromCache: true,
     };
   }
 
   const data = await context.unleashClient.listProjects();
-  cachedProjects = {
-    data,
-    fetchedAt: now,
-  };
+  context.cache.projects = { data, fetchedAt: now };
 
   return {
     projects: data,
@@ -470,7 +456,7 @@ async function getCachedFeatureFlags(
   fromCache: boolean;
 }> {
   const now = Date.now();
-  const cached = cachedFeatureFlags.get(projectId);
+  const cached = context.cache.featureFlags.get(projectId);
 
   if (cached && now - cached.fetchedAt < FEATURE_FLAGS_CACHE_TTL_MS) {
     return {
@@ -481,10 +467,7 @@ async function getCachedFeatureFlags(
   }
 
   const data = await context.unleashClient.listFeatureFlags(projectId);
-  cachedFeatureFlags.set(projectId, {
-    data,
-    fetchedAt: now,
-  });
+  context.cache.featureFlags.set(projectId, { data, fetchedAt: now });
 
   return {
     flags: data,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,249 @@
+import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Variables } from '@modelcontextprotocol/sdk/shared/uriTemplate.js';
+import { UriTemplate } from '@modelcontextprotocol/sdk/shared/uriTemplate.js';
+import { type Config, normalizeBaseUrl } from './config.js';
+import { createLogger, type Logger, type ServerContext } from './context.js';
+import {
+  extractFlagNameFromFeatureUri,
+  extractProjectIdFromFeatureUri,
+  FEATURE_FLAG_RESOURCE_URI,
+  FEATURE_FLAGS_RESOURCE_TEMPLATE,
+  isFeatureFlagsUri,
+  isFeatureFlagUri,
+  isProjectsUri,
+  PROJECTS_RESOURCE_TEMPLATE,
+  parseFeatureFlagsResourceOptions,
+  parseProjectsResourceOptions,
+  readFeatureFlagResource,
+  readFeatureFlagsResource,
+  readProjectsResource,
+} from './resources/unleashResources.js';
+import { cleanupFlagTool } from './tools/cleanupFlag.js';
+import { createFlagTool } from './tools/createFlag.js';
+import { detectFlagTool } from './tools/detectFlag.js';
+import { evaluateChangeTool } from './tools/evaluateChange.js';
+import { getFlagStateTool } from './tools/getFlagState.js';
+import { removeFlagStrategyTool } from './tools/removeFlagStrategy.js';
+import { setFlagRolloutTool } from './tools/setFlagRollout.js';
+import { toggleFlagEnvironmentTool } from './tools/toggleFlagEnvironment.js';
+import type { ToolDefinition } from './tools/types.js';
+import { wrapChangeTool } from './tools/wrapChange.js';
+import { UnleashClient } from './unleash/client.js';
+import { notifyProgress } from './utils/streaming.js';
+import { VERSION } from './version.js';
+
+export interface CreateServerOptions {
+  baseUrl: string;
+  authHeaders: Record<string, string>;
+  defaultProject?: string;
+  defaultEnvironment?: string;
+  dryRun?: boolean;
+  logLevel?: 'debug' | 'info' | 'warn' | 'error';
+  logger?: Logger;
+}
+
+class UriTemplateWithMatcher extends UriTemplate {
+  matchFn: (uri: string) => Variables | null;
+
+  constructor(template: string, matchFn: (uri: string) => Variables | null) {
+    super(template);
+    this.matchFn = matchFn;
+  }
+
+  match(uri: string): Variables | null {
+    return this.matchFn(uri);
+  }
+}
+
+export function createUnleashMcpServer(options: CreateServerOptions): McpServer {
+  const baseUrl = normalizeBaseUrl(options.baseUrl);
+  const dryRun = options.dryRun ?? false;
+  const logLevel = options.logLevel ?? 'error';
+  const logger = options.logger ?? createLogger(logLevel);
+
+  // Build a Config object for ServerContext. The pat field is a placeholder —
+  // no tool reads config.unleash.pat; auth is handled via authHeaders in UnleashClient.
+  const config: Config = {
+    unleash: {
+      baseUrl,
+      pat: '',
+      defaultProject: options.defaultProject,
+      defaultEnvironment: options.defaultEnvironment,
+    },
+    server: {
+      dryRun,
+      logLevel,
+    },
+  };
+
+  const unleashClient = new UnleashClient(baseUrl, options.authHeaders, dryRun);
+
+  const instructions = [
+    'Use this tool for local development to increase confidence by decoupling the change from deployments:',
+    '1) Call evaluate_change to get a risk assessment on the current code change.',
+    '2) The evaluate_change tool will automatically call detect_flag to search for existing flags to prevent duplicates.',
+    '3) If an existing flag is found, use it. If the code change is risky and no flag exists, create a feature flag with create_flag.',
+    '4) Use wrap_change to guard code with an Unleash flag.',
+    '5) When a flag is rolled out and ready to be removed, use cleanup_flag to safely remove the flag code while preserving the desired path.',
+  ].join('\n');
+
+  const server = new McpServer(
+    {
+      name: 'unleash-mcp',
+      version: VERSION,
+      title:
+        'Local development assistant. After making a code change follow this workflow: evaluate_change → create_flag → wrap_change to score risk and steer next steps.',
+    },
+    {
+      capabilities: {
+        tools: {},
+        logging: {},
+        resources: {},
+      },
+      instructions,
+    },
+  );
+
+  const context: ServerContext = {
+    config,
+    unleashClient,
+    logger,
+    notifyProgress: notifyProgress(server),
+  };
+
+  type ProgressExtra = { _meta?: { progressToken?: string | number } };
+
+  const tools: ToolDefinition[] = [
+    createFlagTool,
+    evaluateChangeTool,
+    detectFlagTool,
+    wrapChangeTool,
+    cleanupFlagTool,
+    setFlagRolloutTool,
+    getFlagStateTool,
+    toggleFlagEnvironmentTool,
+    removeFlagStrategyTool,
+  ];
+
+  const registerTool = server.registerTool.bind(server) as (
+    name: string,
+    config: { description?: string; inputSchema?: ToolDefinition['inputSchema'] },
+    cb: (args: unknown, extra: ProgressExtra) => unknown,
+  ) => unknown;
+
+  tools.forEach((tool) => {
+    registerTool(
+      tool.name,
+      {
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+      },
+      (args: unknown, extra: ProgressExtra) =>
+        tool.implementation(context, args, extra._meta?.progressToken),
+    );
+  });
+
+  registerResources(server, context);
+
+  return server;
+}
+
+function registerResources(server: McpServer, context: ServerContext): void {
+  const projectsTemplate = new ResourceTemplate(
+    new UriTemplateWithMatcher(PROJECTS_RESOURCE_TEMPLATE, (uri) =>
+      isProjectsUri(uri) ? {} : null,
+    ),
+    { list: undefined },
+  );
+
+  server.registerResource(
+    'unleash-projects-filtered',
+    projectsTemplate,
+    {
+      mimeType: 'application/json',
+      description:
+        'Unleash projects with optional query parameters. Use limit to control page size, order=asc|desc to sort by creation time, and offset to paginate.',
+    },
+    async (uri: URL, _variables: unknown, _extra: unknown) => ({
+      contents: [await readProjectsResource(context, parseProjectsResourceOptions(uri.toString()))],
+    }),
+  );
+
+  const featureFlagsTemplate = new ResourceTemplate(
+    new UriTemplateWithMatcher(FEATURE_FLAGS_RESOURCE_TEMPLATE, (uri) => {
+      if (!isFeatureFlagsUri(uri)) {
+        return null;
+      }
+
+      const projectId = extractProjectIdFromFeatureUri(uri);
+      return projectId ? { projectId } : null;
+    }),
+    { list: undefined },
+  );
+
+  server.registerResource(
+    'unleash-feature-flags-by-project',
+    featureFlagsTemplate,
+    {
+      mimeType: 'application/json',
+      description:
+        'Feature flags for a specific Unleash project. Replace {projectId}; optional limit/order/offset parameters help paginate flags alphabetically.',
+    },
+    async (uri: URL, variables: any, _extra: unknown) => {
+      const projectId = variables.projectId;
+      if (!projectId) {
+        throw new Error('Project ID missing from feature flags URI');
+      }
+
+      return {
+        contents: [
+          await readFeatureFlagsResource(
+            context,
+            projectId,
+            parseFeatureFlagsResourceOptions(uri.toString()),
+          ),
+        ],
+      };
+    },
+  );
+
+  const featureFlagTemplate = new ResourceTemplate(
+    new UriTemplateWithMatcher(FEATURE_FLAG_RESOURCE_URI, (uri) => {
+      if (!isFeatureFlagUri(uri)) {
+        return null;
+      }
+
+      const projectId = extractProjectIdFromFeatureUri(uri);
+      const flagName = extractFlagNameFromFeatureUri(uri);
+
+      if (!projectId || !flagName) {
+        return null;
+      }
+
+      return { projectId, flagName };
+    }),
+    { list: undefined },
+  );
+
+  server.registerResource(
+    'unleash-feature-flag',
+    featureFlagTemplate,
+    {
+      mimeType: 'application/json',
+      description: 'Single feature flag resource.',
+    },
+    async (_uri: URL, variables: any, _extra: unknown) => {
+      const { projectId, flagName } = variables;
+      if (!projectId) {
+        throw new Error('Project ID missing from feature flag URI');
+      }
+      if (!flagName) {
+        throw new Error('Flag name missing from feature flag URI');
+      }
+
+      return {
+        contents: [await readFeatureFlagResource(context, projectId, flagName)],
+      };
+    },
+  );
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -108,6 +108,7 @@ export function createUnleashMcpServer(options: CreateServerOptions): McpServer 
     config,
     unleashClient,
     logger,
+    cache: { projects: null, featureFlags: new Map() },
     notifyProgress: notifyProgress(server),
   };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -189,8 +189,8 @@ function registerResources(server: McpServer, context: ServerContext): void {
       description:
         'Feature flags for a specific Unleash project. Replace {projectId}; optional limit/order/offset parameters help paginate flags alphabetically.',
     },
-    async (uri: URL, variables: any, _extra: unknown) => {
-      const projectId = variables.projectId;
+    async (uri: URL, variables: Variables, _extra: unknown) => {
+      const projectId = variables.projectId as string | undefined;
       if (!projectId) {
         throw new Error('Project ID missing from feature flags URI');
       }
@@ -232,8 +232,8 @@ function registerResources(server: McpServer, context: ServerContext): void {
       mimeType: 'application/json',
       description: 'Single feature flag resource.',
     },
-    async (_uri: URL, variables: any, _extra: unknown) => {
-      const { projectId, flagName } = variables;
+    async (_uri: URL, variables: Variables, _extra: unknown) => {
+      const { projectId, flagName } = variables as { projectId?: string; flagName?: string };
       if (!projectId) {
         throw new Error('Project ID missing from feature flag URI');
       }

--- a/src/unleash/client.ts
+++ b/src/unleash/client.ts
@@ -130,13 +130,13 @@ export interface FeatureDetails {
  */
 export class UnleashClient {
   private readonly baseUrl: string;
-  private readonly pat: string;
+  private readonly authHeaders: Record<string, string>;
   private readonly dryRun: boolean;
 
-  constructor(baseUrl: string, pat: string, dryRun: boolean = false) {
+  constructor(baseUrl: string, authHeaders: Record<string, string>, dryRun: boolean = false) {
     // Ensure baseUrl doesn't have trailing slash
     this.baseUrl = baseUrl.replace(/\/$/, '');
-    this.pat = pat;
+    this.authHeaders = authHeaders;
     this.dryRun = dryRun;
   }
 
@@ -479,7 +479,7 @@ export class UnleashClient {
     return {
       Accept: 'application/json',
       'Content-Type': 'application/json',
-      Authorization: this.pat.trim(),
+      ...this.authHeaders,
       'X-Unleash-AppName': 'unleash-mcp',
       'User-Agent': `unleash-mcp/${VERSION} (MCP Server)`,
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -333,6 +333,18 @@
     zod "^3.25 || ^4.0"
     zod-to-json-schema "^3.25.0"
 
+"@noble/hashes@^1.1.5":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
+  integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
+
+"@paralleldrive/cuid2@^2.2.2":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz#3d62ea9e7be867d3fa94b9897fab5b0ae187d784"
+  integrity sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==
+  dependencies:
+    "@noble/hashes" "^1.1.5"
+
 "@rollup/rollup-android-arm-eabi@4.53.3":
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz#7e478b66180c5330429dd161bf84dad66b59c8eb"
@@ -443,10 +455,27 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz#38ae84f4c04226c1d56a3b17296ef1e0460ecdfe"
   integrity sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==
 
+"@types/cookiejar@^2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.5.tgz#14a3e83fa641beb169a2dd8422d91c3c345a9a78"
+  integrity sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==
+
 "@types/estree@1.0.8", "@types/estree@^1.0.0":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
+
+"@types/methods@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@types/methods/-/methods-1.1.4.tgz#d3b7ac30ac47c91054ea951ce9eed07b1051e547"
+  integrity sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==
+
+"@types/node@*":
+  version "25.2.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.2.2.tgz#0ddfe326c326afcb3422d32bfe5eb2938e1cb5db"
+  integrity sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==
+  dependencies:
+    undici-types "~7.16.0"
 
 "@types/node@^22.10.2":
   version "22.19.2"
@@ -454,6 +483,24 @@
   integrity sha512-LPM2G3Syo1GLzXLGJAKdqoU35XvrWzGJ21/7sgZTUpbkBaOasTj8tjwn6w+hCkqaa1TfJ/w67rJSwYItlJ2mYw==
   dependencies:
     undici-types "~6.21.0"
+
+"@types/superagent@^8.1.0":
+  version "8.1.9"
+  resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-8.1.9.tgz#28bfe4658e469838ed0bf66d898354bcab21f49f"
+  integrity sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==
+  dependencies:
+    "@types/cookiejar" "^2.1.5"
+    "@types/methods" "^1.1.4"
+    "@types/node" "*"
+    form-data "^4.0.0"
+
+"@types/supertest@^6.0.3":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@types/supertest/-/supertest-6.0.3.tgz#d736f0e994b195b63e1c93e80271a2faf927388c"
+  integrity sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==
+  dependencies:
+    "@types/methods" "^1.1.4"
+    "@types/superagent" "^8.1.0"
 
 "@vitest/expect@2.1.9":
   version "2.1.9"
@@ -539,10 +586,20 @@ ajv@^8.0.0, ajv@^8.17.1:
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
 
+asap@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+  integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
+
 assertion-error@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
   integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
 body-parser@^2.2.1:
   version "2.2.1"
@@ -601,6 +658,18 @@ check-error@^2.1.1:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.1.tgz#87eb876ae71ee388fa0471fe423f494be1d96ccc"
   integrity sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
+component-emitter@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.1.tgz#ef1d5796f7d93f135ee6fb684340b26403c97d17"
+  integrity sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==
+
 content-disposition@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-1.0.1.tgz#a8b7bbeb2904befdfb6787e5c0c086959f605f9b"
@@ -611,7 +680,7 @@ content-type@^1.0.5:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
   integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
 
-cookie-signature@^1.2.1:
+cookie-signature@^1.2.1, cookie-signature@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.2.2.tgz#57c7fc3cc293acab9fec54d73e15690ebe4a1793"
   integrity sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==
@@ -620,6 +689,11 @@ cookie@^0.7.1:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
+
+cookiejar@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.4.tgz#ee669c1fea2cf42dc31585469d193fef0d65771b"
+  integrity sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==
 
 cors@^2.8.5:
   version "2.8.5"
@@ -650,10 +724,23 @@ deep-eql@^5.0.1:
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-5.0.2.tgz#4b756d8d770a9257300825d52a2c2cff99c3a341"
   integrity sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==
 
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
 depd@^2.0.0, depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
+dezalgo@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.4.tgz#751235260469084c132157dfa857f386d4c33d81"
+  integrity sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==
+  dependencies:
+    asap "^2.0.0"
+    wrappy "1"
 
 dotenv@^16.4.7:
   version "16.6.1"
@@ -700,6 +787,16 @@ es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
   dependencies:
     es-errors "^1.3.0"
+
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
 
 esbuild@^0.21.3:
   version "0.21.5"
@@ -840,6 +937,11 @@ fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
+fast-safe-stringify@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
+  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
+
 fast-uri@^3.0.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
@@ -856,6 +958,26 @@ finalhandler@^2.1.0:
     on-finished "^2.4.1"
     parseurl "^1.3.3"
     statuses "^2.0.1"
+
+form-data@^4.0.0, form-data@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
+  integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
+    mime-types "^2.1.12"
+
+formidable@^3.5.4:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-3.5.4.tgz#ac9a593b951e829b3298f21aa9a2243932f32ed9"
+  integrity sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==
+  dependencies:
+    "@paralleldrive/cuid2" "^2.2.2"
+    dezalgo "^1.0.4"
+    once "^1.4.0"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -877,7 +999,7 @@ function-bind@^1.1.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
-get-intrinsic@^1.2.5, get-intrinsic@^1.3.0:
+get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -913,10 +1035,17 @@ gopd@^1.2.0:
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
-has-symbols@^1.1.0:
+has-symbols@^1.0.3, has-symbols@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
   integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
+
+has-tostringtag@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
+  integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
+  dependencies:
+    has-symbols "^1.0.3"
 
 hasown@^2.0.2:
   version "2.0.2"
@@ -1005,10 +1134,27 @@ merge-descriptors@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-2.0.0.tgz#ea922f660635a2249ee565e0449f951e6b603808"
   integrity sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==
 
+methods@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
+  integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
+
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
 mime-db@^1.54.0:
   version "1.54.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
   integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
 
 mime-types@^3.0.0, mime-types@^3.0.1:
   version "3.0.2"
@@ -1016,6 +1162,11 @@ mime-types@^3.0.0, mime-types@^3.0.1:
   integrity sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==
   dependencies:
     mime-db "^1.54.0"
+
+mime@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
+  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
 ms@^2.1.3:
   version "2.1.3"
@@ -1108,7 +1259,7 @@ proxy-addr@^2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
-qs@^6.14.0:
+qs@^6.14.0, qs@^6.14.1:
   version "6.14.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.1.tgz#a41d85b9d3902f31d27861790506294881871159"
   integrity sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==
@@ -1296,6 +1447,30 @@ std-env@^3.8.0:
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.10.0.tgz#d810b27e3a073047b2b5e40034881f5ea6f9c83b"
   integrity sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==
 
+superagent@^10.3.0:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-10.3.0.tgz#ff1e39e7976b63f8084291d65f5bfbbbbd156989"
+  integrity sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==
+  dependencies:
+    component-emitter "^1.3.1"
+    cookiejar "^2.1.4"
+    debug "^4.3.7"
+    fast-safe-stringify "^2.1.1"
+    form-data "^4.0.5"
+    formidable "^3.5.4"
+    methods "^1.1.2"
+    mime "2.6.0"
+    qs "^6.14.1"
+
+supertest@^7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/supertest/-/supertest-7.2.2.tgz#dac3ee25a2aa59942a7f641e50c838a7c8819204"
+  integrity sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==
+  dependencies:
+    cookie-signature "^1.2.2"
+    methods "^1.1.2"
+    superagent "^10.3.0"
+
 tinybench@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
@@ -1354,6 +1529,11 @@ undici-types@~6.21.0:
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+
+undici-types@~7.16.0:
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
+  integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
 unpipe@~1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -455,6 +455,21 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz#38ae84f4c04226c1d56a3b17296ef1e0460ecdfe"
   integrity sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==
 
+"@types/body-parser@*":
+  version "1.19.6"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.6.tgz#1859bebb8fd7dac9918a45d54c1971ab8b5af474"
+  integrity sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
+"@types/connect@*":
+  version "3.4.38"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.38.tgz#5ba7f3bc4fbbdeaff8dded952e5ff2cc53f8d858"
+  integrity sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==
+  dependencies:
+    "@types/node" "*"
+
 "@types/cookiejar@^2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.5.tgz#14a3e83fa641beb169a2dd8422d91c3c345a9a78"
@@ -464,6 +479,30 @@
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
+
+"@types/express-serve-static-core@^5.0.0":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz#1a77faffee9572d39124933259be2523837d7eaa"
+  integrity sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+    "@types/send" "*"
+
+"@types/express@^5.0.6":
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-5.0.6.tgz#2d724b2c990dcb8c8444063f3580a903f6d500cc"
+  integrity sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^5.0.0"
+    "@types/serve-static" "^2"
+
+"@types/http-errors@*":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-2.0.5.tgz#5b749ab2b16ba113423feb1a64a95dcd30398472"
+  integrity sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==
 
 "@types/methods@^1.1.4":
   version "1.1.4"
@@ -483,6 +522,31 @@
   integrity sha512-LPM2G3Syo1GLzXLGJAKdqoU35XvrWzGJ21/7sgZTUpbkBaOasTj8tjwn6w+hCkqaa1TfJ/w67rJSwYItlJ2mYw==
   dependencies:
     undici-types "~6.21.0"
+
+"@types/qs@*":
+  version "6.14.0"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.14.0.tgz#d8b60cecf62f2db0fb68e5e006077b9178b85de5"
+  integrity sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==
+
+"@types/range-parser@*":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
+  integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
+
+"@types/send@*":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@types/send/-/send-1.2.1.tgz#6a784e45543c18c774c049bff6d3dbaf045c9c74"
+  integrity sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/serve-static@^2":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-2.2.0.tgz#d4a447503ead0d1671132d1ab6bd58b805d8de6a"
+  integrity sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==
+  dependencies:
+    "@types/http-errors" "*"
+    "@types/node" "*"
 
 "@types/superagent@^8.1.0":
   version "8.1.9"
@@ -898,7 +962,7 @@ express-rate-limit@^7.5.0:
   resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-7.5.1.tgz#8c3a42f69209a3a1c969890070ece9e20a879dec"
   integrity sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==
 
-express@^5.0.1:
+express@^5.0.1, express@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/express/-/express-5.2.1.tgz#8f21d15b6d327f92b4794ecf8cb08a72f956ac04"
   integrity sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

###  Summary                                                                                                                                                                                                      
                                                                                                                                                                                                               
  - Extract transport-agnostic createUnleashMcpServer() factory into src/server.ts so the MCP server can be embedded inside the Unleash Express backend as a remote HTTP endpoint                              
  - Add createMcpHandler() in src/remote.ts — stateless per-request HTTP handler using StreamableHTTPServerTransport                                                                                           
  - Slim down src/index.ts to stdio-only entry point that calls the factory                                                                                                                                    
                                                                                                                                                                                                               
###  Key decisions

  - authHeaders: Record<string, string> instead of pat: string in UnleashClient — generic enough for both PAT (stdio) and forwarded session cookies (remote) without the client knowing which auth scheme is
  used
  - Stateless per-request model for remote mode — fresh McpServer + transport per HTTP request, no session management. Avoids cross-request state leaks at the cost of repeated server construction (cheap)
  - No Express dependency in production — src/remote.ts uses Node.js IncomingMessage/ServerResponse types. Express Request/Response extend these, so it works seamlessly without coupling
  - Package subpath exports (@unleash/mcp/server, @unleash/mcp/remote) — lets the Unleash backend import only what it needs without reaching into dist/
  - Making remote resources per request scoped

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
