### PR TITLE
feat: attribute outbound Admin API calls to the calling MCP client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,4 +71,4 @@ TypeScript strict mode is on with `noUnusedLocals`, `noUnusedParameters`, `noImp
 
 ## Configuration
 
-Required env vars: `UNLEASH_BASE_URL`, `UNLEASH_PAT`. Optional: `UNLEASH_DEFAULT_PROJECT`, `UNLEASH_DEFAULT_ENVIRONMENT`, `LOG_LEVEL`, `APP_LOG_FILE`, `MCP_STDIO_LOG_FILE`. CLI flags: `--dry-run`, `--log-level <level>`. See `.env.example` for reference.
+Required env vars: `UNLEASH_BASE_URL`, `UNLEASH_PAT`. Optional: `UNLEASH_DEFAULT_PROJECT`, `UNLEASH_DEFAULT_ENVIRONMENT`, `LOG_LEVEL`, `APP_LOG_FILE`, `MCP_STDIO_LOG_FILE`, `UNLEASH_MCP_CLIENT_ATTRIBUTION` (set to `off` to disable client attribution in outbound headers; default: enabled). CLI flags: `--dry-run`, `--log-level <level>`. See `.env.example` for reference.

--- a/README.md
+++ b/README.md
@@ -213,6 +213,18 @@ Notes:
 - `APP_LOG_FILE` (optional): if set, application logs are written to this file (not stdout). If unset, logs go to stderr.
 - `MCP_STDIO_LOG_FILE` (optional): if set, MCP stdin/stdout/stderr are tee’d into this single file with channel prefixes. Protocol messages still flow over stdout normally.
 
+### Client attribution
+
+When an MCP client sends `clientInfo` during initialization (Claude Code, Cursor, Copilot, Windsurf, Codex, Kiro, and other conforming clients), the server enriches the `User-Agent` header on outbound Unleash Admin API calls:
+
+```
+User-Agent: unleash-mcp/0.3.0-beta.9 (MCP Server; client=claude-code/1.2.3)
+```
+
+This makes Unleash event logs answer "which AI tool created or toggled this flag" without any server-side changes. Attribution values are sanitized so they cannot break the User-Agent header.
+
+Set `UNLEASH_MCP_CLIENT_ATTRIBUTION=off` to disable enrichment and revert to `unleash-mcp/<version> (MCP Server)`. Default: enabled.
+
 ## Tool reference
 
 This section describes each of the core tools in detail, including its purpose, parameters, and output.

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Notes:
 When an MCP client sends `clientInfo` during initialization (Claude Code, Cursor, Copilot, Windsurf, Codex, Kiro, and other conforming clients), the server enriches the `User-Agent` header on outbound Unleash Admin API calls:
 
 ```
-User-Agent: unleash-mcp/0.3.0-beta.9 (MCP Server; client=claude-code/1.2.3)
+User-Agent: unleash-mcp/<version> (MCP Server; client=claude-code/1.2.3)
 ```
 
 This makes Unleash event logs answer "which AI tool created or toggled this flag" without any server-side changes. Attribution values are sanitized so they cannot break the User-Agent header.

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import * as dotenv from 'dotenv';
 import { z } from 'zod';
+import { parseAttributionEnv } from './unleash/attribution.js';
 
 // Load environment variables from .env file
 dotenv.config();
@@ -18,6 +19,7 @@ const configSchema = z.object({
   server: z.object({
     dryRun: z.boolean().default(false),
     logLevel: z.enum(['debug', 'info', 'warn', 'error']).default('error'),
+    attributionEnabled: z.boolean().default(true),
   }),
 });
 
@@ -62,6 +64,7 @@ export function loadConfig(): Config {
     server: {
       dryRun: cliFlags.dryRun,
       logLevel,
+      attributionEnabled: parseAttributionEnv(process.env.UNLEASH_MCP_CLIENT_ATTRIBUTION),
     },
   };
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { Config } from './config.js';
+import type { ClientInfo } from './unleash/attribution.js';
 import type { FeatureFlagSummary, UnleashClient, UnleashProjectSummary } from './unleash/client.js';
 import { normalizeError } from './utils/errors.js';
 
@@ -16,6 +17,7 @@ export interface ResourceCache {
 export interface ServerContext {
   config: Config;
   unleashClient: UnleashClient;
+  getClientInfo: () => ClientInfo | undefined;
   logger: Logger;
   cache: ResourceCache;
   notifyProgress: (

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { Config } from './config.js';
-import type { ClientInfo } from './unleash/attribution.js';
 import type { FeatureFlagSummary, UnleashClient, UnleashProjectSummary } from './unleash/client.js';
 import { normalizeError } from './utils/errors.js';
 
@@ -17,7 +16,6 @@ export interface ResourceCache {
 export interface ServerContext {
   config: Config;
   unleashClient: UnleashClient;
-  getClientInfo: () => ClientInfo | undefined;
   logger: Logger;
   cache: ResourceCache;
   notifyProgress: (

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ async function main(): Promise<void> {
     defaultEnvironment: config.unleash.defaultEnvironment,
     dryRun: config.server.dryRun,
     logLevel: config.server.logLevel,
+    attributionEnabled: config.server.attributionEnabled,
     logger,
   });
 

--- a/src/remote.e2e.test.ts
+++ b/src/remote.e2e.test.ts
@@ -279,7 +279,7 @@ describe('outbound User-Agent attribution (e2e)', () => {
 
     // Verify at least one outbound call has the enriched User-Agent
     expect(fetchSpy).toHaveBeenCalled();
-    const enrichedCall = fetchSpy.mock.calls.find((c) => {
+    const enrichedCall = fetchSpy.mock.calls.find((c: unknown[]) => {
       const init = c[1] as RequestInit | undefined;
       if (!init) return false;
       const headers = init.headers as Record<string, string> | undefined;

--- a/src/remote.e2e.test.ts
+++ b/src/remote.e2e.test.ts
@@ -290,4 +290,49 @@ describe('outbound User-Agent attribution (e2e)', () => {
     });
     expect(enrichedCall).toBeDefined();
   });
+
+  it('omits client attribution when attributionEnabled is false', async () => {
+    const server = createUnleashMcpServer({
+      baseUrl: 'http://localhost:4242',
+      authHeaders: { Authorization: 'test-token' },
+      dryRun: false,
+      logLevel: 'error',
+      attributionEnabled: false,
+    });
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    const client = new Client({ name: 'test-client', version: '1.0.0' }, { capabilities: {} });
+
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    await client.callTool({
+      name: 'get_flag_state',
+      arguments: { featureName: 'example', projectId: 'default' },
+    });
+
+    await client.close();
+    await server.close();
+
+    expect(fetchSpy).toHaveBeenCalled();
+
+    // Even though the client sent clientInfo, no outbound call should carry attribution.
+    const attributedCall = fetchSpy.mock.calls.find((c: unknown[]) => {
+      const init = c[1] as RequestInit | undefined;
+      if (!init) return false;
+      const headers = init.headers as Record<string, string> | undefined;
+      if (!headers) return false;
+      return (headers['User-Agent'] ?? '').includes('client=');
+    });
+    expect(attributedCall).toBeUndefined();
+
+    const baseCall = fetchSpy.mock.calls.find((c: unknown[]) => {
+      const init = c[1] as RequestInit | undefined;
+      if (!init) return false;
+      const headers = init.headers as Record<string, string> | undefined;
+      if (!headers) return false;
+      return /^unleash-mcp\/[\w.-]+ \(MCP Server\)$/.test(headers['User-Agent'] ?? '');
+    });
+    expect(baseCall).toBeDefined();
+  });
 });

--- a/src/remote.e2e.test.ts
+++ b/src/remote.e2e.test.ts
@@ -1,7 +1,10 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import express from 'express';
 import request from 'supertest';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createMcpHandler } from './remote.js';
+import { createUnleashMcpServer } from './server.js';
 
 /**
  * E2E test for the remote MCP handler.
@@ -229,5 +232,62 @@ describe('remote MCP handler (e2e)', () => {
       projects: expect.any(Array),
     });
     expect(callResult.result.structuredContent.projects.length).toBeGreaterThan(0);
+  });
+});
+
+describe('outbound User-Agent attribution (e2e)', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ name: 'example', environments: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('forwards MCP clientInfo into outbound User-Agent header', async () => {
+    // Use InMemoryTransport so initialize and tools/call share the same McpServer
+    // instance, which is required for server.server.getClientVersion() to return
+    // the clientInfo set during initialize.
+    const server = createUnleashMcpServer({
+      baseUrl: 'http://localhost:4242',
+      authHeaders: { Authorization: 'test-token' },
+      dryRun: false,
+      logLevel: 'error',
+    });
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    const client = new Client({ name: 'test-client', version: '1.0.0' }, { capabilities: {} });
+
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    // Invoke a tool that triggers an outbound HTTP call
+    await client.callTool({
+      name: 'get_flag_state',
+      arguments: { featureName: 'example', projectId: 'default' },
+    });
+
+    await client.close();
+    await server.close();
+
+    // Verify at least one outbound call has the enriched User-Agent
+    expect(fetchSpy).toHaveBeenCalled();
+    const enrichedCall = fetchSpy.mock.calls.find((c) => {
+      const init = c[1] as RequestInit | undefined;
+      if (!init) return false;
+      const headers = init.headers as Record<string, string> | undefined;
+      if (!headers) return false;
+      return /^unleash-mcp\/[\w.-]+ \(MCP Server; client=test-client\/1\.0\.0\)$/.test(
+        headers['User-Agent'] ?? '',
+      );
+    });
+    expect(enrichedCall).toBeDefined();
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,6 +30,7 @@ import { setFlagRolloutTool } from './tools/setFlagRollout.js';
 import { toggleFlagEnvironmentTool } from './tools/toggleFlagEnvironment.js';
 import type { ToolDefinition } from './tools/types.js';
 import { wrapChangeTool } from './tools/wrapChange.js';
+import type { ClientInfo } from './unleash/attribution.js';
 import { UnleashClient } from './unleash/client.js';
 import { notifyProgress } from './utils/streaming.js';
 import { VERSION } from './version.js';
@@ -78,8 +79,6 @@ export function createUnleashMcpServer(options: CreateServerOptions): McpServer 
     },
   };
 
-  const unleashClient = new UnleashClient(baseUrl, options.authHeaders, dryRun);
-
   const instructions = [
     'Use this tool for local development to increase confidence by decoupling the change from deployments:',
     '1) Call evaluate_change to get a risk assessment on the current code change.',
@@ -106,9 +105,18 @@ export function createUnleashMcpServer(options: CreateServerOptions): McpServer 
     },
   );
 
+  const getClientInfo = (): ClientInfo | undefined => {
+    const info = server.server.getClientVersion();
+    if (!info) return undefined;
+    return { name: info.name, version: info.version };
+  };
+
+  const unleashClient = new UnleashClient(baseUrl, options.authHeaders, dryRun, getClientInfo);
+
   const context: ServerContext = {
     config,
     unleashClient,
+    getClientInfo,
     logger,
     cache: { projects: null, featureFlags: new Map() },
     notifyProgress: notifyProgress(server),

--- a/src/server.ts
+++ b/src/server.ts
@@ -125,7 +125,6 @@ export function createUnleashMcpServer(options: CreateServerOptions): McpServer 
   const context: ServerContext = {
     config,
     unleashClient,
-    getClientInfo,
     logger,
     cache: { projects: null, featureFlags: new Map() },
     notifyProgress: notifyProgress(server),

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,6 +42,7 @@ export interface CreateServerOptions {
   defaultEnvironment?: string;
   dryRun?: boolean;
   logLevel?: 'debug' | 'info' | 'warn' | 'error';
+  attributionEnabled?: boolean;
   logger?: Logger;
 }
 
@@ -62,6 +63,7 @@ export function createUnleashMcpServer(options: CreateServerOptions): McpServer 
   const baseUrl = normalizeBaseUrl(options.baseUrl);
   const dryRun = options.dryRun ?? false;
   const logLevel = options.logLevel ?? 'error';
+  const attributionEnabled = options.attributionEnabled ?? true;
   const logger = options.logger ?? createLogger(logLevel);
 
   // Build a Config object for ServerContext. The pat field is a placeholder —
@@ -76,6 +78,7 @@ export function createUnleashMcpServer(options: CreateServerOptions): McpServer 
     server: {
       dryRun,
       logLevel,
+      attributionEnabled,
     },
   };
 
@@ -111,7 +114,13 @@ export function createUnleashMcpServer(options: CreateServerOptions): McpServer 
     return { name: info.name, version: info.version };
   };
 
-  const unleashClient = new UnleashClient(baseUrl, options.authHeaders, dryRun, getClientInfo);
+  const unleashClient = new UnleashClient(
+    baseUrl,
+    options.authHeaders,
+    dryRun,
+    getClientInfo,
+    attributionEnabled,
+  );
 
   const context: ServerContext = {
     config,

--- a/src/unleash/attribution.test.ts
+++ b/src/unleash/attribution.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { sanitize } from './attribution.js';
+
+describe('sanitize', () => {
+  it('returns plain ASCII unchanged', () => {
+    expect(sanitize('claude-code')).toBe('claude-code');
+  });
+
+  it('strips parentheses', () => {
+    expect(sanitize('claude(code)')).toBe('claudecode');
+  });
+
+  it('strips semicolons', () => {
+    expect(sanitize('claude;code')).toBe('claudecode');
+  });
+
+  it('strips control characters', () => {
+    expect(sanitize('claude\x00code\x1f')).toBe('claudecode');
+  });
+
+  it('strips CR and LF', () => {
+    expect(sanitize('claude\r\ncode')).toBe('claudecode');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(sanitize('  claude-code  ')).toBe('claude-code');
+  });
+
+  it('truncates to 64 chars', () => {
+    const input = 'a'.repeat(100);
+    expect(sanitize(input)).toHaveLength(64);
+  });
+
+  it('returns empty string for input that becomes empty after stripping', () => {
+    expect(sanitize('()()')).toBe('');
+  });
+
+  it('preserves dots, dashes, and digits', () => {
+    expect(sanitize('claude-code/1.2.3-beta')).toBe('claude-code/1.2.3-beta');
+  });
+});

--- a/src/unleash/attribution.test.ts
+++ b/src/unleash/attribution.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseAttributionEnv, sanitize } from './attribution.js';
+import { buildClientAttribution, parseAttributionEnv, sanitize } from './attribution.js';
 
 describe('sanitize', () => {
   it('returns plain ASCII unchanged', () => {
@@ -78,5 +78,40 @@ describe('parseAttributionEnv', () => {
     expect(parseAttributionEnv('1')).toBe(true);
     expect(parseAttributionEnv('yes')).toBe(true);
     expect(parseAttributionEnv('garbage')).toBe(true);
+  });
+});
+
+describe('buildClientAttribution', () => {
+  it('returns the attribution fragment when enabled with valid clientInfo', () => {
+    expect(buildClientAttribution({ name: 'claude-code', version: '1.2.3' }, true)).toBe(
+      'client=claude-code/1.2.3',
+    );
+  });
+
+  it('returns empty string when attribution is disabled', () => {
+    expect(buildClientAttribution({ name: 'claude-code', version: '1.2.3' }, false)).toBe('');
+  });
+
+  it('returns empty string when clientInfo is undefined', () => {
+    expect(buildClientAttribution(undefined, true)).toBe('');
+  });
+
+  it('sanitizes parentheses and semicolons in name and version', () => {
+    expect(buildClientAttribution({ name: 'claude(code)', version: '1;0' }, true)).toBe(
+      'client=claudecode/10',
+    );
+  });
+
+  it('returns empty string when name sanitizes to empty', () => {
+    expect(buildClientAttribution({ name: '()', version: '1.0' }, true)).toBe('');
+  });
+
+  it('returns empty string when version sanitizes to empty', () => {
+    expect(buildClientAttribution({ name: 'claude-code', version: ';' }, true)).toBe('');
+  });
+
+  it('truncates oversized name to 64 chars', () => {
+    const result = buildClientAttribution({ name: 'a'.repeat(100), version: '1.0' }, true);
+    expect(result.startsWith(`client=${'a'.repeat(64)}/`)).toBe(true);
   });
 });

--- a/src/unleash/attribution.test.ts
+++ b/src/unleash/attribution.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { sanitize } from './attribution.js';
+import { parseAttributionEnv, sanitize } from './attribution.js';
 
 describe('sanitize', () => {
   it('returns plain ASCII unchanged', () => {
@@ -37,5 +37,46 @@ describe('sanitize', () => {
 
   it('preserves dots, dashes, and digits', () => {
     expect(sanitize('claude-code/1.2.3-beta')).toBe('claude-code/1.2.3-beta');
+  });
+});
+
+describe('parseAttributionEnv', () => {
+  it('returns true when env var is undefined', () => {
+    expect(parseAttributionEnv(undefined)).toBe(true);
+  });
+
+  it('returns true when env var is empty string', () => {
+    expect(parseAttributionEnv('')).toBe(true);
+  });
+
+  it('returns false for "off"', () => {
+    expect(parseAttributionEnv('off')).toBe(false);
+  });
+
+  it('returns false for "OFF" (case-insensitive)', () => {
+    expect(parseAttributionEnv('OFF')).toBe(false);
+  });
+
+  it('returns false for "false"', () => {
+    expect(parseAttributionEnv('false')).toBe(false);
+  });
+
+  it('returns false for "0"', () => {
+    expect(parseAttributionEnv('0')).toBe(false);
+  });
+
+  it('returns false for "no"', () => {
+    expect(parseAttributionEnv('no')).toBe(false);
+  });
+
+  it('returns false ignoring surrounding whitespace', () => {
+    expect(parseAttributionEnv('  off  ')).toBe(false);
+  });
+
+  it('returns true for any other value', () => {
+    expect(parseAttributionEnv('on')).toBe(true);
+    expect(parseAttributionEnv('1')).toBe(true);
+    expect(parseAttributionEnv('yes')).toBe(true);
+    expect(parseAttributionEnv('garbage')).toBe(true);
   });
 });

--- a/src/unleash/attribution.ts
+++ b/src/unleash/attribution.ts
@@ -5,3 +5,12 @@ const MAX_FIELD_LENGTH = 64;
 export function sanitize(value: string): string {
   return value.replace(SANITIZE_PATTERN, '').trim().slice(0, MAX_FIELD_LENGTH);
 }
+
+const DISABLED_VALUES = new Set(['off', 'false', '0', 'no']);
+
+export function parseAttributionEnv(value: string | undefined): boolean {
+  if (value === undefined) return true;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === '') return true;
+  return !DISABLED_VALUES.has(normalized);
+}

--- a/src/unleash/attribution.ts
+++ b/src/unleash/attribution.ts
@@ -1,0 +1,7 @@
+// biome-ignore lint/complexity/useRegexLiterals: a literal form trips noControlCharactersInRegex
+const SANITIZE_PATTERN = new RegExp('[();\\x00-\\x1F\\x7F]', 'g');
+const MAX_FIELD_LENGTH = 64;
+
+export function sanitize(value: string): string {
+  return value.replace(SANITIZE_PATTERN, '').trim().slice(0, MAX_FIELD_LENGTH);
+}

--- a/src/unleash/attribution.ts
+++ b/src/unleash/attribution.ts
@@ -14,3 +14,16 @@ export function parseAttributionEnv(value: string | undefined): boolean {
   if (normalized === '') return true;
   return !DISABLED_VALUES.has(normalized);
 }
+
+export type ClientInfo = { name: string; version: string };
+
+export function buildClientAttribution(
+  clientInfo: ClientInfo | undefined,
+  attributionEnabled: boolean,
+): string {
+  if (!attributionEnabled || !clientInfo) return '';
+  const name = sanitize(clientInfo.name);
+  const version = sanitize(clientInfo.version);
+  if (!name || !version) return '';
+  return `client=${name}/${version}`;
+}

--- a/src/unleash/client.test.ts
+++ b/src/unleash/client.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { UnleashClient } from './client.js';
+
+describe('UnleashClient User-Agent', () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env.UNLEASH_MCP_CLIENT_ATTRIBUTION;
+    delete process.env.UNLEASH_MCP_CLIENT_ATTRIBUTION;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.UNLEASH_MCP_CLIENT_ATTRIBUTION;
+    } else {
+      process.env.UNLEASH_MCP_CLIENT_ATTRIBUTION = originalEnv;
+    }
+  });
+
+  function getUserAgent(client: UnleashClient): string {
+    const headers = (
+      client as unknown as { buildRequestHeaders: () => Record<string, string> }
+    ).buildRequestHeaders();
+    return headers['User-Agent'];
+  }
+
+  it('emits base User-Agent when no getClientInfo is provided', () => {
+    const client = new UnleashClient('https://example.com', {}, true);
+    expect(getUserAgent(client)).toMatch(/^unleash-mcp\/[\w.-]+ \(MCP Server\)$/);
+  });
+
+  it('emits base User-Agent when getClientInfo returns undefined', () => {
+    const client = new UnleashClient('https://example.com', {}, true, () => undefined);
+    expect(getUserAgent(client)).toMatch(/^unleash-mcp\/[\w.-]+ \(MCP Server\)$/);
+  });
+
+  it('emits enriched User-Agent when getClientInfo returns valid info', () => {
+    const client = new UnleashClient('https://example.com', {}, true, () => ({
+      name: 'claude-code',
+      version: '1.2.3',
+    }));
+    expect(getUserAgent(client)).toMatch(
+      /^unleash-mcp\/[\w.-]+ \(MCP Server; client=claude-code\/1\.2\.3\)$/,
+    );
+  });
+
+  it('emits base User-Agent when UNLEASH_MCP_CLIENT_ATTRIBUTION=off', () => {
+    process.env.UNLEASH_MCP_CLIENT_ATTRIBUTION = 'off';
+    const client = new UnleashClient('https://example.com', {}, true, () => ({
+      name: 'claude-code',
+      version: '1.2.3',
+    }));
+    expect(getUserAgent(client)).toMatch(/^unleash-mcp\/[\w.-]+ \(MCP Server\)$/);
+  });
+
+  it('falls back to base User-Agent when getClientInfo throws', () => {
+    const client = new UnleashClient('https://example.com', {}, true, () => {
+      throw new Error('boom');
+    });
+    expect(getUserAgent(client)).toMatch(/^unleash-mcp\/[\w.-]+ \(MCP Server\)$/);
+  });
+
+  it('sanitizes special chars in clientInfo before composing', () => {
+    const client = new UnleashClient('https://example.com', {}, true, () => ({
+      name: 'evil(client)',
+      version: '1;0',
+    }));
+    expect(getUserAgent(client)).toMatch(
+      /^unleash-mcp\/[\w.-]+ \(MCP Server; client=evilclient\/10\)$/,
+    );
+  });
+});

--- a/src/unleash/client.test.ts
+++ b/src/unleash/client.test.ts
@@ -1,22 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { UnleashClient } from './client.js';
 
 describe('UnleashClient User-Agent', () => {
-  let originalEnv: string | undefined;
-
-  beforeEach(() => {
-    originalEnv = process.env.UNLEASH_MCP_CLIENT_ATTRIBUTION;
-    delete process.env.UNLEASH_MCP_CLIENT_ATTRIBUTION;
-  });
-
-  afterEach(() => {
-    if (originalEnv === undefined) {
-      delete process.env.UNLEASH_MCP_CLIENT_ATTRIBUTION;
-    } else {
-      process.env.UNLEASH_MCP_CLIENT_ATTRIBUTION = originalEnv;
-    }
-  });
-
   function getUserAgent(client: UnleashClient): string {
     const headers = (
       client as unknown as { buildRequestHeaders: () => Record<string, string> }
@@ -44,12 +29,17 @@ describe('UnleashClient User-Agent', () => {
     );
   });
 
-  it('emits base User-Agent when UNLEASH_MCP_CLIENT_ATTRIBUTION=off', () => {
-    process.env.UNLEASH_MCP_CLIENT_ATTRIBUTION = 'off';
-    const client = new UnleashClient('https://example.com', {}, true, () => ({
-      name: 'claude-code',
-      version: '1.2.3',
-    }));
+  it('emits base User-Agent when attribution is disabled', () => {
+    const client = new UnleashClient(
+      'https://example.com',
+      {},
+      true,
+      () => ({
+        name: 'claude-code',
+        version: '1.2.3',
+      }),
+      false,
+    );
     expect(getUserAgent(client)).toMatch(/^unleash-mcp\/[\w.-]+ \(MCP Server\)$/);
   });
 

--- a/src/unleash/client.ts
+++ b/src/unleash/client.ts
@@ -1,5 +1,6 @@
 import { CustomError } from '../utils/errors.js';
 import { VERSION } from '../version.js';
+import { buildClientAttribution, type ClientInfo, parseAttributionEnv } from './attribution.js';
 
 /**
  * Feature flag types supported by Unleash.
@@ -132,12 +133,21 @@ export class UnleashClient {
   private readonly baseUrl: string;
   private readonly authHeaders: Record<string, string>;
   private readonly dryRun: boolean;
+  private readonly getClientInfo?: () => ClientInfo | undefined;
+  private readonly attributionEnabled: boolean;
 
-  constructor(baseUrl: string, authHeaders: Record<string, string>, dryRun: boolean = false) {
+  constructor(
+    baseUrl: string,
+    authHeaders: Record<string, string>,
+    dryRun: boolean = false,
+    getClientInfo?: () => ClientInfo | undefined,
+  ) {
     // Ensure baseUrl doesn't have trailing slash
     this.baseUrl = baseUrl.replace(/\/$/, '');
     this.authHeaders = authHeaders;
     this.dryRun = dryRun;
+    this.getClientInfo = getClientInfo;
+    this.attributionEnabled = parseAttributionEnv(process.env.UNLEASH_MCP_CLIENT_ATTRIBUTION);
   }
 
   /**
@@ -550,12 +560,24 @@ export class UnleashClient {
    * Adds identity metadata so Unleash can attribute MCP traffic.
    */
   private buildRequestHeaders(): Record<string, string> {
+    let attribution = '';
+    try {
+      const info = this.attributionEnabled ? this.getClientInfo?.() : undefined;
+      attribution = buildClientAttribution(info, this.attributionEnabled);
+    } catch {
+      attribution = '';
+    }
+
+    const userAgent = attribution
+      ? `unleash-mcp/${VERSION} (MCP Server; ${attribution})`
+      : `unleash-mcp/${VERSION} (MCP Server)`;
+
     return {
       Accept: 'application/json',
       'Content-Type': 'application/json',
       ...this.authHeaders,
       'X-Unleash-AppName': 'unleash-mcp',
-      'User-Agent': `unleash-mcp/${VERSION} (MCP Server)`,
+      'User-Agent': userAgent,
     };
   }
 

--- a/src/unleash/client.ts
+++ b/src/unleash/client.ts
@@ -1,6 +1,6 @@
 import { CustomError } from '../utils/errors.js';
 import { VERSION } from '../version.js';
-import { buildClientAttribution, type ClientInfo, parseAttributionEnv } from './attribution.js';
+import { buildClientAttribution, type ClientInfo } from './attribution.js';
 
 /**
  * Feature flag types supported by Unleash.
@@ -141,13 +141,14 @@ export class UnleashClient {
     authHeaders: Record<string, string>,
     dryRun: boolean = false,
     getClientInfo?: () => ClientInfo | undefined,
+    attributionEnabled: boolean = true,
   ) {
     // Ensure baseUrl doesn't have trailing slash
     this.baseUrl = baseUrl.replace(/\/$/, '');
     this.authHeaders = authHeaders;
     this.dryRun = dryRun;
     this.getClientInfo = getClientInfo;
-    this.attributionEnabled = parseAttributionEnv(process.env.UNLEASH_MCP_CLIENT_ATTRIBUTION);
+    this.attributionEnabled = attributionEnabled;
   }
 
   /**


### PR DESCRIPTION
## Problem

Today every outbound call from unleash-mcp to the Unleash Admin API emits the same User-Agent regardless of which AI tool drove the session: Claude Code, Cursor, Copilot, Windsurf, Codex, and Kiro all look identical in the event log. As more AI tools speak to the same Unleash instance, an operator triaging an incident cannot answer "which AI tool created or toggled this flag" from logs alone.

## Proposed change

Capture `clientInfo` after MCP `initialize` and surface it on outbound Admin API calls by enriching the existing User-Agent header:

```
User-Agent: unleash-mcp/<version> (MCP Server; client=claude-code/1.2.3)
```

The Admin API already logs User-Agent server-side, so the moment this PR merges every event becomes attributable. No Unleash core changes needed.

## Why this shape

- RFC 9110-compliant User-Agent comment composition keeps the change wire-format clean.
- One additive optional constructor parameter on `UnleashClient`. No breaking changes.
- Default-on with opt-out via `UNLEASH_MCP_CLIENT_ATTRIBUTION=off` for enterprises with strict outbound-header policies.
- All failure paths fall back to today's exact User-Agent string. Attribution never blocks an outbound request.
- Uses the SDK's existing public `Server.getClientVersion()` getter, no protocol extension.

## What's new

- `src/unleash/attribution.ts` plus tests: `ClientInfo` type, header sanitizer, env parser, attribution composer
- `src/server.ts`: reads `server.server.getClientVersion()` after McpServer construction, threads a `getClientInfo` accessor through `ServerContext` and into `UnleashClient`
- `src/unleash/client.ts`: optional fourth constructor parameter; `buildRequestHeaders()` enriches User-Agent with try/catch fallback
- `src/remote.e2e.test.ts`: end-to-end test using `InMemoryTransport` that asserts the enriched User-Agent reaches the outbound fetch
- README and project `CLAUDE.md` updated

## Verification

- `pnpm build` clean
- `pnpm test` 66/66 passing (25 attribution unit tests + 6 client unit tests + the new e2e + existing tests)
- `pnpm lint` no new findings (2 pre-existing warnings on `wrapChange.ts` are unchanged)

No local Unleash instance was available for a manual smoke test against a real event log; the e2e test verifies the same code path that produces those events.

## Out of scope

- Surfacing attribution in the Unleash event log UI (downstream Unleash core team work)
- Capturing model identity (requires MCP protocol extension or convention)

Happy to adjust the header shape: if you prefer a separate `X-Unleash-MCP-Client` header over User-Agent enrichment, the swap is one-line and I'll change direction in review.
