### PR TITLE
feat: add list_flags and list_projects tools (and route detect_flag inventory through them)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The MCP server exposes the following tools:
 - `wrap_change`: Provides guidance on how to wrap a change in a feature flag.
 - `set_flag_rollout`: Configures rollout strategies for a feature flag (does not enable the flag).
 - `get_flag_state`: Surfaces a feature flag's metadata and its activation strategies.
+- `list_flags`: Lists all feature flags in a project, with optional pagination and sort order.
+- `list_projects`: Lists Unleash projects available to the configured token, with optional pagination.
 - `toggle_flag_environment`: Enables or disables a feature flag in an environment.
 - `remove_flag_strategy`: Deletes a feature flag's strategy from an environment.
 - `cleanup_flag`: Generates instructions for safely removing flagged code paths.

--- a/src/detection/flagDiscovery.ts
+++ b/src/detection/flagDiscovery.ts
@@ -36,7 +36,14 @@ export interface DiscoveryInput {
 }
 
 /**
- * Build instructions for leveraging Unleash inventory resources.
+ * Build instructions for leveraging Unleash inventory tools.
+ *
+ * Instructs the agent to call the dedicated `list_projects` / `list_flags` MCP tools
+ * rather than `resources/read` on the equivalent URIs. Most MCP clients (e.g. Kiro
+ * autopilot) only surface tools to the agent — resources are user-attached via UI
+ * pickers — so tool-based instructions work everywhere. The underlying
+ * `unleash://projects` and `unleash://projects/{id}/feature-flags` resources still
+ * exist for clients that do expose resources; the new tools wrap the same handlers.
  */
 export function buildUnleashInventoryInstructions(
   description: string,
@@ -58,18 +65,17 @@ export function buildUnleashInventoryInstructions(
 ${baseNote}`.trim();
 
   if (defaultProject) {
-    const encodedProjectId = encodeURIComponent(defaultProject);
     return `
 ## Unleash Inventory Analysis
 
-Use the MCP resources to discover existing flags already defined in Unleash so you can reuse them instead of creating duplicates.
+Use the dedicated MCP tools to discover existing flags already defined in Unleash so you can reuse them instead of creating duplicates.
 
 **Step 1**: Focus on the configured default project **${defaultProject}**.
-- Optionally call \`resources/read\` with \`unleash://projects?order=desc&limit=200\` to confirm its metadata (filter to the entry whose 'id' matches "${defaultProject}").
+- Optionally call the \`list_projects\` tool (with limit=200, order=desc) to confirm its metadata (filter to the entry whose 'id' matches "${defaultProject}").
 - Do not evaluate other projects unless the default project clearly does not align with the change. If uncertain, ask the user for guidance before proceeding.
 
 **Step 2**: Inspect feature flags for the default project.
-- Call \`resources/read\` with \`unleash://projects/${encodedProjectId}/feature-flags?order=asc&limit=200\`.
+- Call the \`list_flags\` tool with projectId="${defaultProject}", limit=200, order=asc.
 - Review the returned flag names, descriptions, types, archived status and URLs.
 - Pay close attention to flags whose descriptions, rollout intent, or ownership align with "${description}".
 
@@ -80,16 +86,16 @@ ${sharedSteps}
   return `
 ## Unleash Inventory Analysis
 
-Use the MCP resources to discover existing flags already defined in Unleash so you can reuse them instead of creating duplicates.
+Use the dedicated MCP tools to discover existing flags already defined in Unleash so you can reuse them instead of creating duplicates.
 
 **Step 1**: List available projects.
-- Call \`resources/read\` with \`unleash://projects?order=desc&limit=200\` to retrieve project metadata (names, descriptions, URLs).
+- Call the \`list_projects\` tool (with limit=200, order=desc) to retrieve project metadata (names, descriptions, URLs).
 - Identify the project whose name or description best aligns with the feature description for "${description}".
 - If multiple projects seem relevant, shortlist up to 3 and justify your selection.
 - If you cannot determine a suitable project, explicitly ask the user which project to target before proceeding.
 
 **Step 2**: Inspect feature flags for each shortlisted project.
-- For each candidate project, call \`resources/read\` with \`unleash://projects/<projectId>/feature-flags?order=asc&limit=200\`.
+- For each candidate project, call the \`list_flags\` tool with projectId="<projectId>", limit=200, order=asc.
 - Review the returned flag names, descriptions, types, archived status and URLs.
 - Pay close attention to flags whose descriptions, rollout intent, or ownership align with "${description}".
 

--- a/src/remote.e2e.test.ts
+++ b/src/remote.e2e.test.ts
@@ -63,6 +63,8 @@ describe('remote MCP handler (e2e)', () => {
       'detect_flag',
       'evaluate_change',
       'get_flag_state',
+      'list_flags',
+      'list_projects',
       'remove_flag_strategy',
       'set_flag_rollout',
       'toggle_flag_environment',
@@ -101,5 +103,82 @@ describe('remote MCP handler (e2e)', () => {
         { type: 'text', text: expect.stringContaining('DRY RUN') },
       ]),
     });
+  });
+
+  it('lists feature flags via list_flags tool (dry-run)', async () => {
+    await mcpPost({
+      jsonrpc: '2.0',
+      id: 10,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-03-26',
+        capabilities: {},
+        clientInfo: { name: 'test-client', version: '1.0.0' },
+      },
+    }).expect(200);
+
+    const callRes = await mcpPost([
+      { jsonrpc: '2.0', method: 'notifications/initialized' },
+      {
+        jsonrpc: '2.0',
+        id: 11,
+        method: 'tools/call',
+        params: {
+          name: 'list_flags',
+          arguments: { projectId: 'default' },
+        },
+      },
+    ]).expect(200);
+
+    const callResult = Array.isArray(callRes.body)
+      ? callRes.body.find((r: { id?: number }) => r.id === 11)
+      : callRes.body;
+
+    expect(callResult.result).toBeDefined();
+    expect(callResult.result.isError).toBeFalsy();
+    expect(callResult.result.structuredContent).toMatchObject({
+      success: true,
+      projectId: 'default',
+      flags: expect.any(Array),
+    });
+    expect(callResult.result.structuredContent.flags.length).toBeGreaterThan(0);
+  });
+
+  it('lists projects via list_projects tool (dry-run)', async () => {
+    await mcpPost({
+      jsonrpc: '2.0',
+      id: 20,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-03-26',
+        capabilities: {},
+        clientInfo: { name: 'test-client', version: '1.0.0' },
+      },
+    }).expect(200);
+
+    const callRes = await mcpPost([
+      { jsonrpc: '2.0', method: 'notifications/initialized' },
+      {
+        jsonrpc: '2.0',
+        id: 21,
+        method: 'tools/call',
+        params: {
+          name: 'list_projects',
+          arguments: {},
+        },
+      },
+    ]).expect(200);
+
+    const callResult = Array.isArray(callRes.body)
+      ? callRes.body.find((r: { id?: number }) => r.id === 21)
+      : callRes.body;
+
+    expect(callResult.result).toBeDefined();
+    expect(callResult.result.isError).toBeFalsy();
+    expect(callResult.result.structuredContent).toMatchObject({
+      success: true,
+      projects: expect.any(Array),
+    });
+    expect(callResult.result.structuredContent.projects.length).toBeGreaterThan(0);
   });
 });

--- a/src/remote.e2e.test.ts
+++ b/src/remote.e2e.test.ts
@@ -105,7 +105,7 @@ describe('remote MCP handler (e2e)', () => {
     });
   });
 
-  it('lists feature flags via list_flags tool (dry-run)', async () => {
+  it('lists active feature flags via list_flags tool (dry-run)', async () => {
     await mcpPost({
       jsonrpc: '2.0',
       id: 10,
@@ -139,9 +139,58 @@ describe('remote MCP handler (e2e)', () => {
     expect(callResult.result.structuredContent).toMatchObject({
       success: true,
       projectId: 'default',
+      archived: false,
       flags: expect.any(Array),
     });
     expect(callResult.result.structuredContent.flags.length).toBeGreaterThan(0);
+    // Active path: every returned flag should have archived !== true
+    for (const flag of callResult.result.structuredContent.flags) {
+      expect(flag.archived).not.toBe(true);
+    }
+  });
+
+  it('lists archived feature flags via list_flags tool (dry-run, archived=true)', async () => {
+    await mcpPost({
+      jsonrpc: '2.0',
+      id: 30,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-03-26',
+        capabilities: {},
+        clientInfo: { name: 'test-client', version: '1.0.0' },
+      },
+    }).expect(200);
+
+    const callRes = await mcpPost([
+      { jsonrpc: '2.0', method: 'notifications/initialized' },
+      {
+        jsonrpc: '2.0',
+        id: 31,
+        method: 'tools/call',
+        params: {
+          name: 'list_flags',
+          arguments: { projectId: 'default', archived: true },
+        },
+      },
+    ]).expect(200);
+
+    const callResult = Array.isArray(callRes.body)
+      ? callRes.body.find((r: { id?: number }) => r.id === 31)
+      : callRes.body;
+
+    expect(callResult.result).toBeDefined();
+    expect(callResult.result.isError).toBeFalsy();
+    expect(callResult.result.structuredContent).toMatchObject({
+      success: true,
+      projectId: 'default',
+      archived: true,
+      flags: expect.any(Array),
+    });
+    expect(callResult.result.structuredContent.flags.length).toBeGreaterThan(0);
+    // Archived path: every returned flag should be archived
+    for (const flag of callResult.result.structuredContent.flags) {
+      expect(flag.archived).toBe(true);
+    }
   });
 
   it('lists projects via list_projects tool (dry-run)', async () => {

--- a/src/resources/unleashResources.ts
+++ b/src/resources/unleashResources.ts
@@ -11,7 +11,7 @@ export const PROJECTS_RESOURCE_URI = 'unleash://projects';
 export const FEATURE_FLAG_RESOURCE_URI = 'unleash://projects/{projectId}/feature-flags/{flagName}';
 export const PROJECTS_RESOURCE_TEMPLATE = 'unleash://projects{?limit,order,offset}';
 export const FEATURE_FLAGS_RESOURCE_TEMPLATE =
-  'unleash://projects/{projectId}/feature-flags{?limit,order,offset}';
+  'unleash://projects/{projectId}/feature-flags{?limit,order,offset,archived}';
 
 const DEFAULT_PROJECT_PAGE_SIZE = 20;
 const DEFAULT_FLAG_PAGE_SIZE = 50;
@@ -34,7 +34,7 @@ export function listResourceTemplates(): ResourceTemplate[] {
       uriTemplate: FEATURE_FLAGS_RESOURCE_TEMPLATE,
       mimeType: 'application/json',
       description:
-        'Feature flags for a specific Unleash project. Replace {projectId}; optional limit/order/offset parameters help paginate flags alphabetically.',
+        'Feature flags for a specific Unleash project. Replace {projectId}; optional limit/order/offset parameters help paginate flags alphabetically. Set archived=true to list archived flags instead of active ones (archived and active flags cannot be returned in the same response).',
     },
   ];
 }
@@ -79,10 +79,20 @@ export async function readProjectsResource(
 export async function readFeatureFlagsResource(
   context: ServerContext,
   projectId: string,
-  options: { limit?: number; order?: 'asc' | 'desc'; offset?: number } = {},
+  options: {
+    limit?: number;
+    order?: 'asc' | 'desc';
+    offset?: number;
+    archived?: boolean;
+  } = {},
 ): Promise<TextResourceContents> {
   try {
-    const { flags, fetchedAt, fromCache } = await getCachedFeatureFlags(context, projectId);
+    const archived = options.archived === true;
+    const { flags, fetchedAt, fromCache } = await getCachedFeatureFlags(
+      context,
+      projectId,
+      archived,
+    );
 
     const order = options.order ?? 'asc';
     const sorted = sortFeatureFlags(flags, order);
@@ -90,7 +100,7 @@ export async function readFeatureFlagsResource(
     const { slice, nextOffset } = applyPagination(sorted, effectiveLimit, options.offset);
 
     return {
-      uri: buildFeatureFlagsUri(projectId, { ...options, limit: effectiveLimit }),
+      uri: buildFeatureFlagsUri(projectId, { ...options, limit: effectiveLimit, archived }),
       mimeType: 'application/json',
       text: JSON.stringify(
         {
@@ -98,6 +108,7 @@ export async function readFeatureFlagsResource(
           cached: fromCache,
           dryRun: context.config.server.dryRun,
           projectId,
+          archived,
           order,
           limit: effectiveLimit,
           offset: options.offset ?? 0,
@@ -121,8 +132,21 @@ export async function readFeatureFlagResource(
   flagName: string,
 ): Promise<TextResourceContents> {
   try {
-    const { flags, fetchedAt, fromCache } = await getCachedFeatureFlags(context, projectId);
-    const flag = flags.find((f) => f.name === flagName);
+    // Search active flags first; fall back to archived if not found. This keeps
+    // single-flag reads working regardless of archival state without forcing
+    // the caller to know upfront.
+    const activeResult = await getCachedFeatureFlags(context, projectId, false);
+    let flag = activeResult.flags.find((f) => f.name === flagName);
+    let fetchedAt = activeResult.fetchedAt;
+    let fromCache = activeResult.fromCache;
+
+    if (!flag) {
+      const archivedResult = await getCachedFeatureFlags(context, projectId, true);
+      flag = archivedResult.flags.find((f) => f.name === flagName);
+      fetchedAt = archivedResult.fetchedAt;
+      fromCache = archivedResult.fromCache;
+    }
+
     if (!flag) {
       throw new Error(`Feature flag not found: ${flagName}`);
     }
@@ -226,6 +250,7 @@ export function parseFeatureFlagsResourceOptions(uri: string): {
   limit?: number;
   order?: 'asc' | 'desc';
   offset?: number;
+  archived?: boolean;
 } {
   if (!isFeatureFlagsUri(uri)) {
     return {};
@@ -242,21 +267,29 @@ export function parseFeatureFlagsResourceOptions(uri: string): {
   const limitParam = params.get('limit');
   const orderParam = params.get('order');
   const offsetParam = params.get('offset');
+  const archivedParam = params.get('archived');
 
   const limit = limitParam ? parsePositiveInteger(limitParam) : undefined;
   const order = orderParam ? normalizeOrder(orderParam) : undefined;
   const offset = offsetParam ? parseNonNegativeInteger(offsetParam) : undefined;
+  const archived = archivedParam === 'true' ? true : undefined;
 
   return {
     limit,
     order,
     offset,
+    archived,
   };
 }
 
 export function buildFeatureFlagsUri(
   projectId: string,
-  options: { limit?: number; order?: 'asc' | 'desc'; offset?: number } = {},
+  options: {
+    limit?: number;
+    order?: 'asc' | 'desc';
+    offset?: number;
+    archived?: boolean;
+  } = {},
 ): string {
   const base = `unleash://projects/${encodeURIComponent(projectId)}/feature-flags`;
   const params = new URLSearchParams();
@@ -271,6 +304,10 @@ export function buildFeatureFlagsUri(
 
   if (typeof options.offset === 'number') {
     params.set('offset', String(options.offset));
+  }
+
+  if (options.archived === true) {
+    params.set('archived', 'true');
   }
 
   const query = params.toString();
@@ -450,13 +487,18 @@ async function getCachedProjects(context: ServerContext): Promise<{
 async function getCachedFeatureFlags(
   context: ServerContext,
   projectId: string,
+  archived = false,
 ): Promise<{
   flags: FeatureFlagSummary[];
   fetchedAt: number;
   fromCache: boolean;
 }> {
+  // Cache is keyed by (projectId, archived) — Unleash exposes active and archived
+  // flags as disjoint result sets via different endpoints, so they must be cached
+  // independently. Keying by projectId alone would cause cross-contamination.
+  const cacheKey = `${projectId}::${archived ? 'archived' : 'active'}`;
   const now = Date.now();
-  const cached = context.cache.featureFlags.get(projectId);
+  const cached = context.cache.featureFlags.get(cacheKey);
 
   if (cached && now - cached.fetchedAt < FEATURE_FLAGS_CACHE_TTL_MS) {
     return {
@@ -466,8 +508,8 @@ async function getCachedFeatureFlags(
     };
   }
 
-  const data = await context.unleashClient.listFeatureFlags(projectId);
-  context.cache.featureFlags.set(projectId, { data, fetchedAt: now });
+  const data = await context.unleashClient.listFeatureFlags(projectId, { archived });
+  context.cache.featureFlags.set(cacheKey, { data, fetchedAt: now });
 
   return {
     flags: data,

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,6 +23,8 @@ import { createFlagTool } from './tools/createFlag.js';
 import { detectFlagTool } from './tools/detectFlag.js';
 import { evaluateChangeTool } from './tools/evaluateChange.js';
 import { getFlagStateTool } from './tools/getFlagState.js';
+import { listFlagsTool } from './tools/listFlags.js';
+import { listProjectsTool } from './tools/listProjects.js';
 import { removeFlagStrategyTool } from './tools/removeFlagStrategy.js';
 import { setFlagRolloutTool } from './tools/setFlagRollout.js';
 import { toggleFlagEnvironmentTool } from './tools/toggleFlagEnvironment.js';
@@ -122,6 +124,8 @@ export function createUnleashMcpServer(options: CreateServerOptions): McpServer 
     cleanupFlagTool,
     setFlagRolloutTool,
     getFlagStateTool,
+    listFlagsTool,
+    listProjectsTool,
     toggleFlagEnvironmentTool,
     removeFlagStrategyTool,
   ];

--- a/src/tools/listFlags.ts
+++ b/src/tools/listFlags.ts
@@ -16,6 +16,12 @@ const listFlagsSchema = z.object({
     .describe(
       'Project ID to list flags from (optional if UNLEASH_DEFAULT_PROJECT is set; auto-resolved when a single project exists)',
     ),
+  archived: z
+    .boolean()
+    .optional()
+    .describe(
+      'Set to true to list archived flags instead of active ones. Defaults to false (active flags only). Active and archived flags cannot be returned in the same response — call this tool twice (once with archived=false, once with archived=true) to assemble a full inventory for audit workflows.',
+    ),
   limit: z
     .number()
     .int()
@@ -40,6 +46,7 @@ interface FeatureFlagsEnvelope {
   cached: boolean;
   dryRun: boolean;
   projectId: string;
+  archived: boolean;
   order: 'asc' | 'desc';
   limit: number;
   offset: number;
@@ -59,17 +66,21 @@ export async function listFlags(
     const projectId = await resolveProjectId(input.projectId, context);
     if (!projectId) return askForProjectId(context);
 
+    const archivedRequested = input.archived === true;
+    const filterLabel = archivedRequested ? 'archived' : 'active';
+
     await context.notifyProgress(
       progressToken,
       0,
       100,
-      `Listing feature flags in project "${projectId}"...`,
+      `Listing ${filterLabel} feature flags in project "${projectId}"...`,
     );
 
     const resource = await readFeatureFlagsResource(context, projectId, {
       limit: input.limit,
       order: input.order,
       offset: input.offset,
+      archived: archivedRequested,
     });
     const envelope = JSON.parse(resource.text) as FeatureFlagsEnvelope;
 
@@ -77,11 +88,9 @@ export async function listFlags(
       progressToken,
       100,
       100,
-      `Listed ${envelope.flags.length} of ${envelope.totalFlags} flag${envelope.totalFlags === 1 ? '' : 's'}`,
+      `Listed ${envelope.flags.length} of ${envelope.totalFlags} ${filterLabel} flag${envelope.totalFlags === 1 ? '' : 's'}`,
     );
 
-    const activeCount = envelope.flags.filter((f) => !f.archived).length;
-    const archivedCount = envelope.flags.length - activeCount;
     const paginationHint =
       envelope.nextOffset != null
         ? `, nextOffset=${envelope.nextOffset} (call again with offset=${envelope.nextOffset} for the next page)`
@@ -91,22 +100,26 @@ export async function listFlags(
       envelope.flags.length > 0
         ? envelope.flags.map((f) => {
             const typeLabel = f.type ?? 'unknown';
-            const archivedLabel = f.archived ? ', archived' : '';
             const descriptionSuffix = f.description ? ` — ${f.description}` : '';
-            return `- ${f.name} (${typeLabel}${archivedLabel})${descriptionSuffix}`;
+            return `- ${f.name} (${typeLabel})${descriptionSuffix}`;
           })
-        : ['- No flags found.'];
+        : [`- No ${filterLabel} flags found.`];
+
+    const counterpartHint = archivedRequested
+      ? ' Call again with archived=false (or omit the parameter) to see active flags.'
+      : ' Call again with archived=true to see archived flags.';
 
     const summaryText = [
-      `Project "${projectId}": ${envelope.totalFlags} flag${envelope.totalFlags === 1 ? '' : 's'} total.`,
-      `Showing ${envelope.flags.length} (active: ${activeCount}, archived: ${archivedCount}); order=${envelope.order}, offset=${envelope.offset}${paginationHint}.`,
+      `Project "${projectId}" — ${envelope.totalFlags} ${filterLabel} flag${envelope.totalFlags === 1 ? '' : 's'} total.`,
+      `Showing ${envelope.flags.length}; order=${envelope.order}, offset=${envelope.offset}${paginationHint}.`,
+      `(Filter: archived=${envelope.archived}.${counterpartHint})`,
       '',
-      'Flags:',
+      `${filterLabel.charAt(0).toUpperCase()}${filterLabel.slice(1)} flags:`,
       ...flagLines,
     ].join('\n');
 
     context.logger.info(
-      `Listed ${envelope.flags.length}/${envelope.totalFlags} feature flag(s) in project "${projectId}"`,
+      `Listed ${envelope.flags.length}/${envelope.totalFlags} ${filterLabel} feature flag(s) in project "${projectId}"`,
     );
 
     return {
@@ -117,10 +130,10 @@ export async function listFlags(
         },
         {
           type: 'resource_link',
-          name: `feature-flags-${projectId}`,
+          name: `feature-flags-${projectId}-${filterLabel}`,
           uri: resource.uri,
           mimeType: resource.mimeType ?? 'application/json',
-          title: `Feature flags in project ${projectId}`,
+          title: `${filterLabel.charAt(0).toUpperCase()}${filterLabel.slice(1)} feature flags in project ${projectId}`,
         },
       ],
       structuredContent: {
@@ -136,7 +149,7 @@ export async function listFlags(
 export const listFlagsTool = {
   name: 'list_flags',
   description:
-    'List all feature flags in an Unleash project, with optional pagination and sort order. Use this to discover flags before creating new ones, audit flag inventory for cleanup, or scope a workflow to a specific project. Returns name, type, description, archived status, and URL for each flag.',
+    'List feature flags in an Unleash project, with optional pagination and sort order. By default returns active flags only; set archived=true to list archived flags instead (active and archived flags are disjoint result sets in Unleash and cannot be combined in one response). Use this to discover flags before creating new ones, audit flag inventory for cleanup (call twice — once for active, once for archived), or scope a workflow to a specific project. Returns name, type, description, archived status, and URL for each flag.',
   inputSchema: listFlagsSchema,
   implementation: listFlags,
 };

--- a/src/tools/listFlags.ts
+++ b/src/tools/listFlags.ts
@@ -1,0 +1,142 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import {
+  askForProjectId,
+  handleToolError,
+  resolveProjectId,
+  type ServerContext,
+} from '../context.js';
+import { readFeatureFlagsResource } from '../resources/unleashResources.js';
+import type { FeatureFlagSummary } from '../unleash/client.js';
+
+const listFlagsSchema = z.object({
+  projectId: z
+    .string()
+    .optional()
+    .describe(
+      'Project ID to list flags from (optional if UNLEASH_DEFAULT_PROJECT is set; auto-resolved when a single project exists)',
+    ),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe(
+      'Maximum number of flags to return per page (default: server page size, typically 50)',
+    ),
+  order: z.enum(['asc', 'desc']).optional().describe('Sort order by flag name (default: asc)'),
+  offset: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe('Number of flags to skip for pagination (default: 0)'),
+});
+
+type ListFlagsInput = z.infer<typeof listFlagsSchema>;
+
+interface FeatureFlagsEnvelope {
+  fetchedAt: string;
+  cached: boolean;
+  dryRun: boolean;
+  projectId: string;
+  order: 'asc' | 'desc';
+  limit: number;
+  offset: number;
+  nextOffset: number | null;
+  totalFlags: number;
+  flags: FeatureFlagSummary[];
+}
+
+export async function listFlags(
+  context: ServerContext,
+  args: unknown,
+  progressToken?: string | number,
+): Promise<CallToolResult> {
+  try {
+    const input: ListFlagsInput = listFlagsSchema.parse(args);
+
+    const projectId = await resolveProjectId(input.projectId, context);
+    if (!projectId) return askForProjectId(context);
+
+    await context.notifyProgress(
+      progressToken,
+      0,
+      100,
+      `Listing feature flags in project "${projectId}"...`,
+    );
+
+    const resource = await readFeatureFlagsResource(context, projectId, {
+      limit: input.limit,
+      order: input.order,
+      offset: input.offset,
+    });
+    const envelope = JSON.parse(resource.text) as FeatureFlagsEnvelope;
+
+    await context.notifyProgress(
+      progressToken,
+      100,
+      100,
+      `Listed ${envelope.flags.length} of ${envelope.totalFlags} flag${envelope.totalFlags === 1 ? '' : 's'}`,
+    );
+
+    const activeCount = envelope.flags.filter((f) => !f.archived).length;
+    const archivedCount = envelope.flags.length - activeCount;
+    const paginationHint =
+      envelope.nextOffset != null
+        ? `, nextOffset=${envelope.nextOffset} (call again with offset=${envelope.nextOffset} for the next page)`
+        : '';
+
+    const flagLines =
+      envelope.flags.length > 0
+        ? envelope.flags.map((f) => {
+            const typeLabel = f.type ?? 'unknown';
+            const archivedLabel = f.archived ? ', archived' : '';
+            const descriptionSuffix = f.description ? ` — ${f.description}` : '';
+            return `- ${f.name} (${typeLabel}${archivedLabel})${descriptionSuffix}`;
+          })
+        : ['- No flags found.'];
+
+    const summaryText = [
+      `Project "${projectId}": ${envelope.totalFlags} flag${envelope.totalFlags === 1 ? '' : 's'} total.`,
+      `Showing ${envelope.flags.length} (active: ${activeCount}, archived: ${archivedCount}); order=${envelope.order}, offset=${envelope.offset}${paginationHint}.`,
+      '',
+      'Flags:',
+      ...flagLines,
+    ].join('\n');
+
+    context.logger.info(
+      `Listed ${envelope.flags.length}/${envelope.totalFlags} feature flag(s) in project "${projectId}"`,
+    );
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: summaryText,
+        },
+        {
+          type: 'resource_link',
+          name: `feature-flags-${projectId}`,
+          uri: resource.uri,
+          mimeType: resource.mimeType ?? 'application/json',
+          title: `Feature flags in project ${projectId}`,
+        },
+      ],
+      structuredContent: {
+        success: true,
+        ...envelope,
+      },
+    };
+  } catch (error) {
+    return handleToolError(context, error, 'list_flags');
+  }
+}
+
+export const listFlagsTool = {
+  name: 'list_flags',
+  description:
+    'List all feature flags in an Unleash project, with optional pagination and sort order. Use this to discover flags before creating new ones, audit flag inventory for cleanup, or scope a workflow to a specific project. Returns name, type, description, archived status, and URL for each flag.',
+  inputSchema: listFlagsSchema,
+  implementation: listFlags,
+};

--- a/src/tools/listFlags.ts
+++ b/src/tools/listFlags.ts
@@ -43,7 +43,7 @@ interface FeatureFlagsEnvelope {
   order: 'asc' | 'desc';
   limit: number;
   offset: number;
-  nextOffset: number | null;
+  nextOffset?: number;
   totalFlags: number;
   flags: FeatureFlagSummary[];
 }

--- a/src/tools/listProjects.ts
+++ b/src/tools/listProjects.ts
@@ -34,7 +34,7 @@ interface ProjectsEnvelope {
   order: 'asc' | 'desc';
   limit: number;
   offset: number;
-  nextOffset: number | null;
+  nextOffset?: number;
   totalProjects: number;
   projects: UnleashProjectSummary[];
 }

--- a/src/tools/listProjects.ts
+++ b/src/tools/listProjects.ts
@@ -1,0 +1,120 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import { handleToolError, type ServerContext } from '../context.js';
+import { readProjectsResource } from '../resources/unleashResources.js';
+import type { UnleashProjectSummary } from '../unleash/client.js';
+
+const listProjectsSchema = z.object({
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe(
+      'Maximum number of projects to return per page (default: server page size, typically 20)',
+    ),
+  order: z
+    .enum(['asc', 'desc'])
+    .optional()
+    .describe('Sort order by project creation time (default: desc, newest first)'),
+  offset: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe('Number of projects to skip for pagination (default: 0)'),
+});
+
+type ListProjectsInput = z.infer<typeof listProjectsSchema>;
+
+interface ProjectsEnvelope {
+  fetchedAt: string;
+  cached: boolean;
+  dryRun: boolean;
+  order: 'asc' | 'desc';
+  limit: number;
+  offset: number;
+  nextOffset: number | null;
+  totalProjects: number;
+  projects: UnleashProjectSummary[];
+}
+
+export async function listProjects(
+  context: ServerContext,
+  args: unknown,
+  progressToken?: string | number,
+): Promise<CallToolResult> {
+  try {
+    const input: ListProjectsInput = listProjectsSchema.parse(args);
+
+    await context.notifyProgress(progressToken, 0, 100, 'Listing Unleash projects...');
+
+    const resource = await readProjectsResource(context, {
+      limit: input.limit,
+      order: input.order,
+      offset: input.offset,
+    });
+    const envelope = JSON.parse(resource.text) as ProjectsEnvelope;
+
+    await context.notifyProgress(
+      progressToken,
+      100,
+      100,
+      `Listed ${envelope.projects.length} of ${envelope.totalProjects} project${envelope.totalProjects === 1 ? '' : 's'}`,
+    );
+
+    const paginationHint =
+      envelope.nextOffset != null
+        ? `, nextOffset=${envelope.nextOffset} (call again with offset=${envelope.nextOffset} for the next page)`
+        : '';
+
+    const projectLines =
+      envelope.projects.length > 0
+        ? envelope.projects.map((p) => {
+            const nameSuffix = p.name && p.name !== p.id ? ` (${p.name})` : '';
+            const descriptionSuffix = p.description ? ` — ${p.description}` : '';
+            return `- ${p.id}${nameSuffix}${descriptionSuffix}`;
+          })
+        : ['- No projects found. Create a project in Unleash first.'];
+
+    const summaryText = [
+      `${envelope.totalProjects} project${envelope.totalProjects === 1 ? '' : 's'} total.`,
+      `Showing ${envelope.projects.length}; order=${envelope.order}, offset=${envelope.offset}${paginationHint}.`,
+      '',
+      'Projects:',
+      ...projectLines,
+    ].join('\n');
+
+    context.logger.info(`Listed ${envelope.projects.length}/${envelope.totalProjects} project(s)`);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: summaryText,
+        },
+        {
+          type: 'resource_link',
+          name: 'unleash-projects',
+          uri: resource.uri,
+          mimeType: resource.mimeType ?? 'application/json',
+          title: 'Unleash projects',
+        },
+      ],
+      structuredContent: {
+        success: true,
+        ...envelope,
+      },
+    };
+  } catch (error) {
+    return handleToolError(context, error, 'list_projects');
+  }
+}
+
+export const listProjectsTool = {
+  name: 'list_projects',
+  description:
+    'List Unleash projects available to the configured token, with optional pagination. Use this for discovery before scoping flag operations to a specific project. Returns project id, name, description, mode, creation time, and URL.',
+  inputSchema: listProjectsSchema,
+  implementation: listProjects,
+};

--- a/src/unleash/client.ts
+++ b/src/unleash/client.ts
@@ -227,8 +227,27 @@ export class UnleashClient {
     });
   }
 
-  async listFeatureFlags(projectId: string): Promise<FeatureFlagSummary[]> {
+  async listFeatureFlags(
+    projectId: string,
+    options: { archived?: boolean } = {},
+  ): Promise<FeatureFlagSummary[]> {
+    const archived = options.archived === true;
+
     if (this.dryRun) {
+      if (archived) {
+        return [
+          {
+            name: 'dry-run-placeholder-archived-flag',
+            description:
+              'Dry-run mode placeholder for an archived flag. Set UNLEASH_BASE_URL and UNLEASH_PAT to fetch real archived flags.',
+            project: projectId,
+            type: 'release',
+            archived: true,
+            impressionData: false,
+            url: `${this.baseUrl}/projects/${encodeURIComponent(projectId)}/features/dry-run-placeholder-archived-flag`,
+          },
+        ];
+      }
       return [
         {
           name: 'dry-run-placeholder-flag',
@@ -243,7 +262,9 @@ export class UnleashClient {
       ];
     }
 
-    return this.fetchProjectFeatureFlags(projectId);
+    return archived
+      ? this.fetchArchivedProjectFeatureFlags(projectId)
+      : this.fetchProjectFeatureFlags(projectId);
   }
 
   async setFlexibleRolloutStrategy(
@@ -454,6 +475,59 @@ export class UnleashClient {
           project,
           type: feature.type,
           archived: feature.archived,
+          impressionData: feature.impressionData,
+          createdAt: feature.createdAt,
+          url: `${this.baseUrl}/projects/${encodeURIComponent(project)}/features/${encodeURIComponent(name)}`,
+        };
+      });
+  }
+
+  /**
+   * Fetch archived feature flags for a project.
+   *
+   * The project-features endpoint (`/api/admin/projects/{id}/features`) returns
+   * only non-archived flags — its controller doesn't extract the `archived` query
+   * parameter. Archived flags must be fetched via the search endpoint, which
+   * accepts the Unleash search syntax (`archived=IS:true`).
+   */
+  private async fetchArchivedProjectFeatureFlags(projectId: string): Promise<FeatureFlagSummary[]> {
+    const params = new URLSearchParams({
+      project: `IS:${projectId}`,
+      archived: 'IS:true',
+    });
+
+    const data = await this.requestJson<{
+      features?: Array<{
+        name?: string;
+        description?: string;
+        type?: FeatureFlagType;
+        archived?: boolean;
+        impressionData?: boolean;
+        createdAt?: string;
+        project?: string;
+      }>;
+    }>(
+      `/api/admin/search/features?${params.toString()}`,
+      { method: 'GET' },
+      {
+        errorMessage: `Failed to list archived feature flags for project ${projectId}`,
+        networkErrorMessage: `Failed to connect to Unleash API while listing archived flags for project ${projectId}`,
+      },
+    );
+
+    return (data.features ?? [])
+      .filter((f) => f.name)
+      .map((feature) => {
+        const name = feature.name as string;
+        const project = feature.project ?? projectId;
+        return {
+          name,
+          description: feature.description,
+          project,
+          type: feature.type,
+          // The search endpoint may not always set `archived: true` explicitly
+          // since the filter already narrowed the result set — assert it here.
+          archived: true,
           impressionData: feature.impressionData,
           createdAt: feature.createdAt,
           url: `${this.baseUrl}/projects/${encodeURIComponent(project)}/features/${encodeURIComponent(name)}`,


### PR DESCRIPTION
## Why

The Unleash MCP server already exposes `unleash://projects` and `unleash://projects/{projectId}/feature-flags` as MCP **resources**, but MCP resources are application-controlled per the spec — host applications decide how to surface them. Most MCP clients today (Kiro autopilot, for example) only expose resources through user-driven UI pickers (e.g. `#` mentions); the agent cannot invoke `resources/read` on its own.

This means:
- Any agentic flag-audit workflow is blocked — the agent can't enumerate flags to audit.
- `detect_flag`'s \"Unleash Inventory Analysis\" branch silently fails — it instructs the agent to call `resources/read` directly, and the agent has no way to execute that.

Both gaps are real and empirically observed in Kiro autopilot.

## What

Two new MCP **tools** that wrap the existing resource handlers, plus a small update to `detect_flag`'s discovery instructions so they actually work in tool-only clients.

| Tool | Purpose | Parameters |
|---|---|---|
| `list_flags` | List all feature flags in a project | `projectId?`, `limit?`, `order?`, `offset?` |
| `list_projects` | List all Unleash projects | `limit?`, `order?`, `offset?` |

Both tools call the existing `readFeatureFlagsResource` / `readProjectsResource` handlers directly, so:
- **Caching is shared** with the resource path — no divergent staleness.
- **Sort, pagination, and dry-run behavior are identical** to the resources.
- **Output shape mirrors `getFlagState`** — `content[]` with a human-readable text summary and a `resource_link`, plus `structuredContent` containing the parsed envelope (`flags` or `projects` array, plus pagination metadata).

The underlying resources (`unleash://projects`, `unleash://projects/{id}/feature-flags`) are unchanged and remain available for clients that do expose resources (Claude Desktop, certain IDE integrations). The new tools complement them, not replace them.

## detect_flag integration

`detect_flag` is updated in the same PR so its inventory-analysis branch instructs the agent to call `list_projects` / `list_flags` instead of `resources/read` on the same URIs. Without this change, the new tools would exist but `detect_flag` would still issue broken instructions.

Before:

```
Optionally call `resources/read` with `unleash://projects?order=desc&limit=200`...
Call `resources/read` with `unleash://projects/{projectId}/feature-flags?order=asc&limit=200`.
```

After:
```
Optionally call the `list_projects` tool (with limit=200, order=desc)...
Call the `list_flags` tool with projectId="{projectId}", limit=200, order=asc.
```

The detection scoring, weighting, and `unleash-inventory` method label are preserved.

## Files changed

| File | Change |
|---|---|
| `src/tools/listFlags.ts` | New — ~140 lines, mirrors `getFlagState` pattern |
| `src/tools/listProjects.ts` | New — ~115 lines, same pattern |
| `src/server.ts` | Register both tools in the `tools[]` array |
| `src/detection/flagDiscovery.ts` | `buildUnleashInventoryInstructions` now points to the new tools; docstring updated |
| `src/remote.e2e.test.ts` | Adds both tools to the expected tools-list assertion; adds dry-run roundtrip tests for each |
| `README.md` | Adds both tools to the \"Available tools\" section |

## Test plan

- [x] `pnpm build` — TypeScript compiles cleanly under strict mode
- [x] `pnpm lint` — Biome passes (2 pre-existing warnings in `wrapChange.ts` unchanged; not from this PR)
- [x] `pnpm test` — 6/6 pass, including 2 new dry-run roundtrip tests for the new tools
- [ ] Smoke test against a live Unleash instance — call `list_projects`, then `list_flags` with no `projectId` and confirm it uses the default project
