### PR TITLE
refactor: make UnleashClient fetch injectable

### DIFF
--- a/src/remote.e2e.test.ts
+++ b/src/remote.e2e.test.ts
@@ -2,7 +2,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import express from 'express';
 import request from 'supertest';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createMcpHandler } from './remote.js';
 import { createUnleashMcpServer } from './server.js';
 
@@ -236,22 +236,19 @@ describe('remote MCP handler (e2e)', () => {
 });
 
 describe('outbound User-Agent attribution (e2e)', () => {
-  let fetchSpy: ReturnType<typeof vi.spyOn>;
-
-  beforeEach(() => {
-    fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ name: 'example', environments: [] }), {
-        status: 200,
-        headers: { 'content-type': 'application/json' },
-      }),
+  function makeFakeFetch() {
+    return vi.fn<typeof fetch>(
+      async () =>
+        new Response(JSON.stringify({ name: 'example', environments: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
     );
-  });
-
-  afterEach(() => {
-    fetchSpy.mockRestore();
-  });
+  }
 
   it('forwards MCP clientInfo into outbound User-Agent header', async () => {
+    const fakeFetch = makeFakeFetch();
+
     // Use InMemoryTransport so initialize and tools/call share the same McpServer
     // instance, which is required for server.server.getClientVersion() to return
     // the clientInfo set during initialize.
@@ -260,6 +257,7 @@ describe('outbound User-Agent attribution (e2e)', () => {
       authHeaders: { Authorization: 'test-token' },
       dryRun: false,
       logLevel: 'error',
+      fetchFn: fakeFetch,
     });
 
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -278,8 +276,8 @@ describe('outbound User-Agent attribution (e2e)', () => {
     await server.close();
 
     // Verify at least one outbound call has the enriched User-Agent
-    expect(fetchSpy).toHaveBeenCalled();
-    const enrichedCall = fetchSpy.mock.calls.find((c: unknown[]) => {
+    expect(fakeFetch).toHaveBeenCalled();
+    const enrichedCall = fakeFetch.mock.calls.find((c: unknown[]) => {
       const init = c[1] as RequestInit | undefined;
       if (!init) return false;
       const headers = init.headers as Record<string, string> | undefined;
@@ -292,12 +290,15 @@ describe('outbound User-Agent attribution (e2e)', () => {
   });
 
   it('omits client attribution when attributionEnabled is false', async () => {
+    const fakeFetch = makeFakeFetch();
+
     const server = createUnleashMcpServer({
       baseUrl: 'http://localhost:4242',
       authHeaders: { Authorization: 'test-token' },
       dryRun: false,
       logLevel: 'error',
       attributionEnabled: false,
+      fetchFn: fakeFetch,
     });
 
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -314,10 +315,10 @@ describe('outbound User-Agent attribution (e2e)', () => {
     await client.close();
     await server.close();
 
-    expect(fetchSpy).toHaveBeenCalled();
+    expect(fakeFetch).toHaveBeenCalled();
 
     // Even though the client sent clientInfo, no outbound call should carry attribution.
-    const attributedCall = fetchSpy.mock.calls.find((c: unknown[]) => {
+    const attributedCall = fakeFetch.mock.calls.find((c: unknown[]) => {
       const init = c[1] as RequestInit | undefined;
       if (!init) return false;
       const headers = init.headers as Record<string, string> | undefined;
@@ -326,7 +327,7 @@ describe('outbound User-Agent attribution (e2e)', () => {
     });
     expect(attributedCall).toBeUndefined();
 
-    const baseCall = fetchSpy.mock.calls.find((c: unknown[]) => {
+    const baseCall = fakeFetch.mock.calls.find((c: unknown[]) => {
       const init = c[1] as RequestInit | undefined;
       if (!init) return false;
       const headers = init.headers as Record<string, string> | undefined;

--- a/src/server.ts
+++ b/src/server.ts
@@ -43,6 +43,7 @@ export interface CreateServerOptions {
   dryRun?: boolean;
   logLevel?: 'debug' | 'info' | 'warn' | 'error';
   attributionEnabled?: boolean;
+  fetchFn?: typeof fetch;
   logger?: Logger;
 }
 
@@ -120,6 +121,7 @@ export function createUnleashMcpServer(options: CreateServerOptions): McpServer 
     dryRun,
     getClientInfo,
     attributionEnabled,
+    options.fetchFn,
   );
 
   const context: ServerContext = {

--- a/src/unleash/client.test.ts
+++ b/src/unleash/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { UnleashClient } from './client.js';
 
 describe('UnleashClient User-Agent', () => {
@@ -58,5 +58,46 @@ describe('UnleashClient User-Agent', () => {
     expect(getUserAgent(client)).toMatch(
       /^unleash-mcp\/[\w.-]+ \(MCP Server; client=evilclient\/10\)$/,
     );
+  });
+});
+
+describe('UnleashClient fetch injection', () => {
+  it('routes requests through the injected fetchFn instead of the global fetch', async () => {
+    const fakeFetch = vi.fn<typeof fetch>(
+      async () =>
+        new Response(
+          JSON.stringify({
+            name: 'new-flag',
+            type: 'release',
+            description: 'A test flag',
+            project: 'default',
+            createdAt: '2026-01-01T00:00:00.000Z',
+            archived: false,
+            impressionData: false,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+    );
+
+    const client = new UnleashClient(
+      'https://example.com',
+      { Authorization: 'token' },
+      false,
+      undefined,
+      true,
+      fakeFetch,
+    );
+
+    const result = await client.createFeatureFlag('default', {
+      name: 'new-flag',
+      type: 'release',
+      description: 'A test flag',
+    });
+
+    expect(fakeFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = fakeFetch.mock.calls[0];
+    expect(url).toBe('https://example.com/api/admin/projects/default/features');
+    expect(init?.method).toBe('POST');
+    expect(result.name).toBe('new-flag');
   });
 });

--- a/src/unleash/client.ts
+++ b/src/unleash/client.ts
@@ -127,7 +127,8 @@ export interface FeatureDetails {
 
 /**
  * Minimal Unleash Admin API client focused on feature flag creation.
- * Uses native fetch (Node 18+) for HTTP requests.
+ * Uses native fetch (Node 18+) by default; the transport is injectable via the
+ * constructor so tests can supply a fake instead of spying on the global fetch.
  */
 export class UnleashClient {
   private readonly baseUrl: string;
@@ -135,6 +136,7 @@ export class UnleashClient {
   private readonly dryRun: boolean;
   private readonly getClientInfo?: () => ClientInfo | undefined;
   private readonly attributionEnabled: boolean;
+  private readonly fetchFn: typeof fetch;
 
   constructor(
     baseUrl: string,
@@ -142,6 +144,7 @@ export class UnleashClient {
     dryRun: boolean = false,
     getClientInfo?: () => ClientInfo | undefined,
     attributionEnabled: boolean = true,
+    fetchFn: typeof fetch = fetch,
   ) {
     // Ensure baseUrl doesn't have trailing slash
     this.baseUrl = baseUrl.replace(/\/$/, '');
@@ -149,6 +152,7 @@ export class UnleashClient {
     this.dryRun = dryRun;
     this.getClientInfo = getClientInfo;
     this.attributionEnabled = attributionEnabled;
+    this.fetchFn = fetchFn;
   }
 
   /**
@@ -378,7 +382,7 @@ export class UnleashClient {
     const headers = this.buildRequestHeaders();
 
     try {
-      const response = await fetch(url, {
+      const response = await this.fetchFn(url, {
         method: 'DELETE',
         headers,
       });
@@ -597,7 +601,7 @@ export class UnleashClient {
     };
 
     try {
-      const response = await fetch(url, {
+      const response = await this.fetchFn(url, {
         ...init,
         headers,
       });
@@ -671,7 +675,7 @@ export class UnleashClient {
     };
 
     try {
-      const response = await fetch(url, {
+      const response = await this.fetchFn(url, {
         ...init,
         headers,
       });


### PR DESCRIPTION
Closes #63.

## Problem

`UnleashClient` receives every collaborator by injection except the one that
makes the network call. `baseUrl`, `authHeaders`, `dryRun`, `getClientInfo`,
and `attributionEnabled` all arrive through the constructor, but the three
request paths called the global `fetch` directly (`client.ts:381`, `:600`,
`:674`). With the transport ambient, the only way to exercise request behavior
was to replace the global, which the attribution e2e test did with
`vi.spyOn(global, 'fetch')` and a beforeEach/afterEach to install and restore it.

## Change

Inject `fetchFn` through the constructor, defaulting to the global, and route
the three sites through it. No behavior change when the default is used.

- `UnleashClient` takes `fetchFn: typeof fetch = fetch` as a sixth positional
  arg, stored as `this.fetchFn` and used at all three request sites.
- `CreateServerOptions` carries an optional `fetchFn` that
  `createUnleashMcpServer` threads into the client, the same way
  `attributionEnabled` already flows. The embedded and remote path picks it up
  through `createMcpHandler`, which spreads its defaults into the factory, so no
  change there.
- The attribution e2e block injects a fake fetch through the factory and
  asserts against it. The `global.fetch` spy and its beforeEach/afterEach are gone.
- Added a unit test in `client.test.ts` that builds the client with a fake and
  asserts the request routes through it.

I kept this to the positional add. The constructor is at six args now, so moving
construction to an options bag is worth a separate pass rather than folding it
in here.

## Testing

`pnpm lint`, `pnpm build`, and `pnpm test` pass (114 tests).

## Why

The attribution work in #59 shapes outbound headers, which is the kind of
behavior that wants a clean test seam. Asserting on an injected fake is more
direct and less brittle than reinstalling a global spy per test, and it closes
the last gap in the client's DI story. It also helps the agentic flag-audit
direction, where exercising request paths under test matters.
