### PR TITLE
fix: Unexpected token '◇', "◇ injected"... is not valid JSON

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,8 @@ import { z } from 'zod';
 import { parseAttributionEnv } from './unleash/attribution.js';
 
 // Load environment variables from .env file
-dotenv.config();
+// quiet: true — dotenv's default tip log writes to stdout, which corrupts the MCP stdio JSON-RPC stream
+dotenv.config({ quiet: true });
 
 /**
  * Configuration schema with Zod validation.


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-768/unleash-mcp-unexpected-token-injected-is-not-valid-json

`dotenv.config()` in `src/config.ts:6` now passes `{ quiet: true }` to stop dotenv's tip banner leaking onto stdout and breaking the MCP JSON-RPC stream.

<img width="675" height="501" alt="image" src="https://github.com/user-attachments/assets/6016f9b1-5a77-4b34-b95d-131c52357293" />
