### PR TITLE
Add MCP tool annotations (title + readOnly/destructive hints)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -148,7 +148,12 @@ export function createUnleashMcpServer(options: CreateServerOptions): McpServer 
 
   const registerTool = server.registerTool.bind(server) as (
     name: string,
-    config: { description?: string; inputSchema?: ToolDefinition['inputSchema'] },
+    config: {
+      title?: string;
+      description?: string;
+      inputSchema?: ToolDefinition['inputSchema'];
+      annotations?: ToolDefinition['annotations'];
+    },
     cb: (args: unknown, extra: ProgressExtra) => unknown,
   ) => unknown;
 
@@ -156,8 +161,10 @@ export function createUnleashMcpServer(options: CreateServerOptions): McpServer 
     registerTool(
       tool.name,
       {
+        title: tool.title,
         description: tool.description,
         inputSchema: tool.inputSchema,
+        annotations: tool.annotations,
       },
       (args: unknown, extra: ProgressExtra) =>
         tool.implementation(context, args, extra._meta?.progressToken),

--- a/src/tools/annotations.test.ts
+++ b/src/tools/annotations.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { cleanupFlagTool } from './cleanupFlag.js';
+import { createFlagTool } from './createFlag.js';
+import { detectFlagTool } from './detectFlag.js';
+import { evaluateChangeTool } from './evaluateChange.js';
+import { getFlagStateTool } from './getFlagState.js';
+import { listFlagsTool } from './listFlags.js';
+import { listProjectsTool } from './listProjects.js';
+import { removeFlagStrategyTool } from './removeFlagStrategy.js';
+import { setFlagRolloutTool } from './setFlagRollout.js';
+import { toggleFlagEnvironmentTool } from './toggleFlagEnvironment.js';
+import type { ToolDefinition } from './types.js';
+import { wrapChangeTool } from './wrapChange.js';
+
+const tools = [
+  createFlagTool,
+  evaluateChangeTool,
+  detectFlagTool,
+  wrapChangeTool,
+  cleanupFlagTool,
+  setFlagRolloutTool,
+  getFlagStateTool,
+  listFlagsTool,
+  listProjectsTool,
+  toggleFlagEnvironmentTool,
+  removeFlagStrategyTool,
+] as ToolDefinition[];
+
+// The Connectors Directory requires every tool to declare a title and the
+// applicable readOnlyHint/destructiveHint. This guards that contract so a new
+// tool can't ship without annotations.
+describe('tool annotations', () => {
+  it.each(
+    tools.map((tool) => [tool.name, tool] as const),
+  )('%s declares a title and read/write hints', (_name, tool) => {
+    expect(tool.title.length).toBeGreaterThan(0);
+    expect(typeof tool.annotations.readOnlyHint).toBe('boolean');
+    // destructiveHint is only meaningful for write tools; require it there.
+    if (tool.annotations.readOnlyHint === false) {
+      expect(typeof tool.annotations.destructiveHint).toBe('boolean');
+    }
+  });
+
+  it('classifies writes and reads as expected', () => {
+    const readOnly = tools
+      .filter((t) => t.annotations.readOnlyHint === true)
+      .map((t) => t.name)
+      .sort();
+    const destructive = tools
+      .filter((t) => t.annotations.destructiveHint === true)
+      .map((t) => t.name)
+      .sort();
+
+    expect(readOnly).toEqual(
+      [
+        'cleanup_flag',
+        'detect_flag',
+        'evaluate_change',
+        'get_flag_state',
+        'list_flags',
+        'list_projects',
+        'wrap_change',
+      ].sort(),
+    );
+    expect(destructive).toEqual(['remove_flag_strategy']);
+  });
+});

--- a/src/tools/cleanupFlag.ts
+++ b/src/tools/cleanupFlag.ts
@@ -264,6 +264,8 @@ Good luck! Take your time and be thorough. 🧹
  */
 export const cleanupFlagTool = {
   name: 'cleanup_flag',
+  title: 'Clean up flag',
+  annotations: { readOnlyHint: true },
   description: `Remove a feature flag from the codebase while preserving the desired code path.
 
 This tool provides comprehensive step-by-step instructions for safely removing feature flag code.

--- a/src/tools/createFlag.ts
+++ b/src/tools/createFlag.ts
@@ -158,6 +158,8 @@ export async function createFlag(
  */
 export const createFlagTool = {
   name: 'create_flag',
+  title: 'Create feature flag',
+  annotations: { readOnlyHint: false, destructiveHint: false },
   description: `Create a new feature flag in Unleash.
 
 This tool creates a feature flag with the specified configuration. Choose the appropriate flag type:

--- a/src/tools/detectFlag.ts
+++ b/src/tools/detectFlag.ts
@@ -164,6 +164,8 @@ Start by executing the file-based detection first, as it's often the most releva
  */
 export const detectFlagTool = {
   name: 'detect_flag',
+  title: 'Detect existing flag',
+  annotations: { readOnlyHint: true },
   description: `Discover existing feature flags in the codebase to prevent duplicates and encourage reuse.
 
 This tool provides comprehensive search instructions for finding existing flags through multiple detection strategies:

--- a/src/tools/evaluateChange.ts
+++ b/src/tools/evaluateChange.ts
@@ -518,6 +518,8 @@ export async function evaluateChange(
  */
 export const evaluateChangeTool = {
   name: 'evaluate_change',
+  title: 'Evaluate change for flag risk',
+  annotations: { readOnlyHint: true },
   description: `Provides comprehensive guidance for evaluating whether code changes require feature flags.
 
 This tool returns detailed evaluation guidelines including:

--- a/src/tools/getFlagState.ts
+++ b/src/tools/getFlagState.ts
@@ -134,6 +134,8 @@ export async function getFlagState(
 
 export const getFlagStateTool = {
   name: 'get_flag_state',
+  title: 'Get flag state',
+  annotations: { readOnlyHint: true },
   description:
     'Fetch the current feature flag metadata and environment strategies from the Unleash Admin API.',
   inputSchema: getFlagStateSchema,

--- a/src/tools/listFlags.ts
+++ b/src/tools/listFlags.ts
@@ -148,6 +148,8 @@ export async function listFlags(
 
 export const listFlagsTool = {
   name: 'list_flags',
+  title: 'List feature flags',
+  annotations: { readOnlyHint: true },
   description:
     'List feature flags in an Unleash project, with optional pagination and sort order. By default returns active flags only; set archived=true to list archived flags instead (active and archived flags are disjoint result sets in Unleash and cannot be combined in one response). Use this to discover flags before creating new ones, audit flag inventory for cleanup (call twice — once for active, once for archived), or scope a workflow to a specific project. Returns name, type, description, archived status, and URL for each flag.',
   inputSchema: listFlagsSchema,

--- a/src/tools/listProjects.ts
+++ b/src/tools/listProjects.ts
@@ -113,6 +113,8 @@ export async function listProjects(
 
 export const listProjectsTool = {
   name: 'list_projects',
+  title: 'List Unleash projects',
+  annotations: { readOnlyHint: true },
   description:
     'List Unleash projects available to the configured token, with optional pagination. Use this for discovery before scoping flag operations to a specific project. Returns project id, name, description, mode, creation time, and URL.',
   inputSchema: listProjectsSchema,

--- a/src/tools/removeFlagStrategy.ts
+++ b/src/tools/removeFlagStrategy.ts
@@ -126,6 +126,8 @@ export async function removeFlagStrategy(
 
 export const removeFlagStrategyTool = {
   name: 'remove_flag_strategy',
+  title: 'Remove flag strategy',
+  annotations: { readOnlyHint: false, destructiveHint: true },
   description:
     'Delete a strategy configuration from a feature flag environment. Use get_flag_state to discover strategy IDs before removal.',
   inputSchema: removeFlagStrategySchema,

--- a/src/tools/setFlagRollout.ts
+++ b/src/tools/setFlagRollout.ts
@@ -154,6 +154,8 @@ export async function setFlagRollout(
 
 export const setFlagRolloutTool = {
   name: 'set_flag_rollout',
+  title: 'Set flag rollout strategy',
+  annotations: { readOnlyHint: false, destructiveHint: false },
   description: `Configure or update a flexibleRollout strategy for a feature flag environment with an optional rollout percentage and variants. This does NOT enable the feature; call toggle_flag_environment to turn environments on or off.`,
   inputSchema: setFlagRolloutSchema,
   implementation: setFlagRollout,

--- a/src/tools/toggleFlagEnvironment.ts
+++ b/src/tools/toggleFlagEnvironment.ts
@@ -132,6 +132,8 @@ export async function toggleFlagEnvironment(
 
 export const toggleFlagEnvironmentTool = {
   name: 'toggle_flag_environment',
+  title: 'Toggle flag in environment',
+  annotations: { readOnlyHint: false, destructiveHint: false },
   description:
     'Enable or disable a feature flag in a specific environment using the Unleash Admin API. For gradual rollouts, configure a flexibleRollout strategy first via set_flag_rollout.',
   inputSchema: toggleFlagEnvironmentSchema,

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -1,4 +1,4 @@
-import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import type { z } from 'zod';
 import type { ServerContext } from '../context.js';
 
@@ -9,8 +9,16 @@ type V4Schema = z.ZodTypeAny;
  */
 export interface ToolDefinition {
   name: string;
+  /** Human-readable display title surfaced to MCP clients and the Connectors Directory. */
+  title: string;
   description: string;
   inputSchema: V4Schema;
+  /**
+   * MCP tool behavior hints. `readOnlyHint` marks tools that do not modify the
+   * Unleash instance; `destructiveHint` marks writes that delete or overwrite
+   * existing configuration (only meaningful when `readOnlyHint` is false).
+   */
+  annotations: ToolAnnotations;
   implementation: (
     context: ServerContext,
     args: unknown,

--- a/src/tools/wrapChange.ts
+++ b/src/tools/wrapChange.ts
@@ -317,6 +317,8 @@ function capitalizeFirst(str: string): string {
  */
 export const wrapChangeTool = {
   name: 'wrap_change',
+  title: 'Wrap change behind a flag',
+  annotations: { readOnlyHint: true },
   description: `Generate code snippets and guidance for wrapping changes with feature flags.
 
 ⚠️ CRITICAL: This tool enforces RUNTIME-CONTROLLABLE feature flags. You MUST place flag checks INSIDE execution paths (handlers, functions), NOT wrapping route registrations, middleware mounting, or controller registration.


### PR DESCRIPTION
## What

Adds a display `title` and MCP **tool annotations** (`readOnlyHint` / `destructiveHint`) to all 11 tools, threaded through `server.registerTool`, plus a guard test.

## Why

- **Required for the Anthropic Connectors Directory** — its submission criteria state every tool must include a `title` and the applicable `readOnlyHint` or `destructiveHint`. We currently ship none.
- **Better UX in every MCP client** — clients that surface annotations (e.g. Claude Code's permission prompts) can distinguish reads from writes and warn appropriately on destructive tools.

## Classification (by the Unleash API call each tool makes)

| Hint | Tools |
|---|---|
| `readOnlyHint: true` | `evaluate_change`, `detect_flag`, `get_flag_state`, `list_projects`, `list_flags` (GET); `wrap_change`, `cleanup_flag` (return code/guidance — no server mutation) |
| write, non-destructive | `create_flag`, `set_flag_rollout`, `toggle_flag_environment` (POST) |
| write, `destructiveHint: true` | `remove_flag_strategy` (DELETE) |

## Changes

- `types.ts`: `ToolDefinition` gains `title` and `annotations: ToolAnnotations`.
- Each tool declares its `title` + `annotations`.
- `server.ts`: registration forwards both to `registerTool`.
- `annotations.test.ts` (new): asserts every tool has a title + hints, and pins the read/write/destructive classification so a new tool can't ship un-annotated.
